### PR TITLE
Make nphysics compatible with projects depending on wasm-bindgen

### DIFF
--- a/build/nphysics2d/Cargo.toml
+++ b/build/nphysics2d/Cargo.toml
@@ -11,7 +11,8 @@ keywords = [ "physics", "dynamics", "rigid", "real-time", "joints" ]
 license = "BSD-3-Clause"
 
 [features]
-default = [ "dim2" ]
+default = [ "dim2", "stdweb" ]
+wasm-bindgen-no-stdweb = [ "dim2", "wasm-bindgen" ]
 dim2    = [ ]
 
 [lib]
@@ -28,13 +29,16 @@ downcast   = "0.9"
 ncollide2d = "0.17"
 
 [target.wasm32-unknown-unknown.dependencies]
-stdweb = "0.4"
+stdweb = {version = "0.4", optional = true}
+wasm-bindgen = {version = "0.2.21", optional = true}
 
 [target.wasm32-unknown-emscripten.dependencies]
-stdweb = "0.4"
+stdweb = {version = "0.4", optional = true}
+wasm-bindgen = {version = "0.2.21", optional = true}
 
 [target.asmjs-unknown-emscripten.dependencies]
-stdweb = "0.4"
+stdweb = {version = "0.4", optional = true}
+wasm-bindgen = {version = "0.2.21", optional = true}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 time = "0.1"

--- a/build/nphysics2d/Cargo.toml
+++ b/build/nphysics2d/Cargo.toml
@@ -12,7 +12,7 @@ license = "BSD-3-Clause"
 
 [features]
 default = [ "dim2", "stdweb" ]
-wasm-bindgen-no-stdweb = [ "dim2", "wasm-bindgen" ]
+use-wasm-bindgen = [ "dim2", "wasm-bindgen" ]
 dim2    = [ ]
 
 [lib]

--- a/build/nphysics3d/Cargo.toml
+++ b/build/nphysics3d/Cargo.toml
@@ -11,7 +11,8 @@ keywords = [ "physics", "dynamics", "rigid", "real-time", "joints" ]
 license = "BSD-3-Clause"
 
 [features]
-default = [ "dim3" ]
+default = [ "dim3", "stdweb" ]
+use-wasm-bindgen = [ "dim3", "wasm-bindgen" ]
 dim3    = [ ]
 
 [lib]
@@ -28,13 +29,16 @@ downcast   = "0.9"
 ncollide3d = "0.17"
 
 [target.wasm32-unknown-unknown.dependencies]
-stdweb = "0.4"
+stdweb = {version = "0.4", optional = true}
+wasm-bindgen = {version = "0.2.21", optional = true}
 
 [target.wasm32-unknown-emscripten.dependencies]
-stdweb = "0.4"
+stdweb = {version = "0.4", optional = true}
+wasm-bindgen = {version = "0.2.21", optional = true}
 
 [target.asmjs-unknown-emscripten.dependencies]
-stdweb = "0.4"
+stdweb = {version = "0.4", optional = true}
+wasm-bindgen = {version = "0.2.21", optional = true}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 time = "0.1"

--- a/src/counters/timer.rs
+++ b/src/counters/timer.rs
@@ -77,7 +77,7 @@ mod js {
     feature = "wasm-bindgen-no-stdweb",
 ))] // Needed because the js macro triggers it.
 fn now() -> f64 {
-    js::performance.now()
+    js::performance.now() / 1000.0
 }
 
 impl Display for Timer {

--- a/src/counters/timer.rs
+++ b/src/counters/timer.rs
@@ -64,7 +64,7 @@ fn now() -> f64 {
     feature = "wasm-bindgen-no-stdweb",
 ))]
 mod js {
-    wasm_bindgen::prelude::*;
+    use wasm_bindgen::prelude::*;
     #[wasm_bindgen]
     extern "C" {
         #[wasm_bindgen(js_namespace = performance)]

--- a/src/counters/timer.rs
+++ b/src/counters/timer.rs
@@ -75,7 +75,7 @@ mod js {
 #[cfg(all(
     any(target_arch = "wasm32", target_arch = "asmjs"),
     feature = "wasm-bindgen-no-stdweb",
-))] // Needed because the js macro triggers it.
+))]
 fn now() -> f64 {
     js::performance.now() / 1000.0
 }

--- a/src/counters/timer.rs
+++ b/src/counters/timer.rs
@@ -77,7 +77,7 @@ mod js {
     feature = "wasm-bindgen-no-stdweb",
 ))]
 fn now() -> f64 {
-    js::performance.now() / 1000.0
+    js::performance::now() / 1000.0
 }
 
 impl Display for Timer {

--- a/src/counters/timer.rs
+++ b/src/counters/timer.rs
@@ -61,7 +61,7 @@ fn now() -> f64 {
 }
 #[cfg(all(
     any(target_arch = "wasm32", target_arch = "asmjs"),
-    feature = "wasm-bindgen-no-stdweb",
+    feature = "use-wasm-bindgen",
 ))]
 mod performance {
     use wasm_bindgen::prelude::*;
@@ -74,7 +74,7 @@ mod performance {
 
 #[cfg(all(
     any(target_arch = "wasm32", target_arch = "asmjs"),
-    feature = "wasm-bindgen-no-stdweb",
+    feature = "use-wasm-bindgen",
 ))]
 fn now() -> f64 {
     performance::now() / 1000.0

--- a/src/counters/timer.rs
+++ b/src/counters/timer.rs
@@ -63,12 +63,12 @@ fn now() -> f64 {
     any(target_arch = "wasm32", target_arch = "asmjs"),
     feature = "wasm-bindgen-no-stdweb",
 ))]
-mod js {
+mod performance {
     use wasm_bindgen::prelude::*;
     #[wasm_bindgen]
     extern "C" {
         #[wasm_bindgen(js_namespace = performance)]
-        fn now() -> f64;
+        pub fn now() -> f64;
     }
 }
 
@@ -77,7 +77,7 @@ mod js {
     feature = "wasm-bindgen-no-stdweb",
 ))]
 fn now() -> f64 {
-    js::performance::now() / 1000.0
+    performance::now() / 1000.0
 }
 
 impl Display for Timer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,13 +83,6 @@ The libraries needed to compile the physics engine are:
 The libraries needed to compile the examples are:
 
 */
-#![cfg_attr(
-  all(
-    any(target_arch = "wasm32", target_arch = "asmjs"),
-    feature = "wasm-bindgen-no-stdweb",
-  ),
-  feature(custom_attribute)
-)]
 #![deny(non_camel_case_types)]
 #![deny(unused_parens)]
 #![deny(non_upper_case_globals)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ extern crate stdweb;
 
 #[cfg(all(
   any(target_arch = "wasm32", target_arch = "asmjs"),
-  feature = "wasm-bindgen-no-stdweb",
+  feature = "use-wasm-bindgen",
 ))]
 extern crate wasm_bindgen;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,13 @@ The libraries needed to compile the physics engine are:
 The libraries needed to compile the examples are:
 
 */
-
+#![cfg_attr(
+  all(
+    any(target_arch = "wasm32", target_arch = "asmjs"),
+    feature = "wasm-bindgen-no-stdweb",
+  ),
+  feature(custom_attribute)
+)]
 #![deny(non_camel_case_types)]
 #![deny(unused_parens)]
 #![deny(non_upper_case_globals)]
@@ -115,9 +121,18 @@ extern crate slab;
 #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
 extern crate time;
 
-#[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
+#[cfg(all(
+  any(target_arch = "wasm32", target_arch = "asmjs"),
+  feature = "stdweb",
+))]
 #[macro_use]
 extern crate stdweb;
+
+#[cfg(all(
+  any(target_arch = "wasm32", target_arch = "asmjs"),
+  feature = "wasm-bindgen-no-std",
+))]
+extern crate wasm_bindgen;
 
 //#[cfg(test)]
 //extern crate test;
@@ -140,7 +155,7 @@ pub mod math {
   use algebra::{Force3, Inertia3, Velocity3};
   use na::{
     Dynamic, Isometry3, Matrix3, Matrix6, MatrixMN, MatrixSlice6xX, MatrixSliceMut6xX, Point3,
-    Translation3, U3, U6, UnitQuaternion, Vector3, Vector6,
+    Translation3, UnitQuaternion, Vector3, Vector6, U3, U6,
   };
 
   /// The maximum number of possible rotations and translations of a rigid body.
@@ -217,7 +232,7 @@ pub mod math {
   use algebra::{Force2, Inertia2, Velocity2};
   use na::{
     Dynamic, Isometry2, Matrix1, Matrix3, MatrixMN, MatrixSlice3xX, MatrixSliceMut3xX, Point2,
-    Translation2, U1, U2, U3, UnitComplex, Vector1, Vector2, Vector3,
+    Translation2, UnitComplex, Vector1, Vector2, Vector3, U1, U2, U3,
   };
 
   /// The maximum number of possible rotations and translations of a rigid body.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ extern crate stdweb;
 
 #[cfg(all(
   any(target_arch = "wasm32", target_arch = "asmjs"),
-  feature = "wasm-bindgen-no-std",
+  feature = "wasm-bindgen-no-stdweb",
 ))]
 extern crate wasm_bindgen;
 


### PR DESCRIPTION
At the moment, projects depending on wasm-bindgen [cannot use nphysics due to a transcient dependency on stdweb](https://github.com/koute/stdweb/issues/263).

This PR adds a new feature, `use-wasm-bindgen`, which uses `wasm-bindgen` instead. This is a non-breaking change, as all dependencies on `stdweb` have been moved to the special `standard` feature.