### PR TITLE
Add methods to disable rotations on RigidBody

### DIFF
--- a/src/object/rigid_body.rs
+++ b/src/object/rigid_body.rs
@@ -344,4 +344,25 @@ impl<N: Real> RigidBody<N> {
         let acc = self.inv_augmented_mass * *force;
         out[..SPATIAL_DIM].copy_from_slice(acc.as_slice());
     }
+
+    /// Set the local inertia of this rigid body.
+    /// Inertia is processed from the given local inertia.
+    #[inline]
+    pub fn set_local_inertia(&mut self, local_inertia: Inertia<N>) {
+        let inertia = local_inertia.transformed(&self.position());
+
+        self.local_inertia = local_inertia;
+        self.inertia = inertia;
+        self.augmented_mass = inertia;
+        self.inv_augmented_mass = inertia.inverse();
+    }
+
+    /// Disable the rotation of this rigid body by removing the angular inertia.
+    #[inline]
+    pub fn disable_rotations(&mut self) {
+        let zero = Inertia::zero();
+        let local_inertia = Inertia::new(self.local_inertia.linear, zero.angular);
+
+        self.set_local_inertia(local_inertia);
+    }
 }

--- a/src/object/rigid_body.rs
+++ b/src/object/rigid_body.rs
@@ -357,7 +357,7 @@ impl<N: Real> RigidBody<N> {
         self.inv_augmented_mass = inertia.inverse();
     }
 
-    /// Disable the rotation of this rigid body by removing the angular inertia.
+    /// Disable rotations of this rigid body by removing the angular inertia.
     #[inline]
     pub fn disable_rotations(&mut self) {
         let zero = Inertia::zero();


### PR DESCRIPTION
Fixes #145 

Feel free to discuss the code, I am pretty new to Rust, and not good at Math :)

Not that I tested this with: https://github.com/fabienjuif/server-physic/pull/1
This part: https://github.com/fabienjuif/server-physic/pull/1/files#diff-639fbc4ef05b315af92b4d836c31b023R63