### PR TITLE
Follow `shellcheck` advices.

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,22 +1,22 @@
 #! /bin/bash
 
-tmp=`mktemp -d`
+tmp=$(mktemp -d)
 
-echo $tmp
+echo "$tmp"
 
-cp -r src $tmp/.
-cp -r LICENSE README.md $tmp/.
+cp -r src "$tmp"/.
+cp -r LICENSE README.md "$tmp"/.
 
 ### Publish the 2D version.
-sed 's#\.\./\.\./src#src#g' build/nphysics2d/Cargo.toml > $tmp/Cargo.toml
-currdir=`pwd`
-cd $tmp && cargo publish
-cd $currdir
+sed 's#\.\./\.\./src#src#g' build/nphysics2d/Cargo.toml > "$tmp"/Cargo.toml
+currdir=$(pwd)
+cd "$tmp" && cargo publish
+cd "$currdir" || exit
 
 
 ### Publish the 3D version.
-sed 's#\.\./\.\./src#src#g' build/nphysics3d/Cargo.toml > $tmp/Cargo.toml
-cp -r LICENSE README.md $tmp/.
-cd $tmp && cargo publish
+sed 's#\.\./\.\./src#src#g' build/nphysics3d/Cargo.toml > "$tmp"/Cargo.toml
+cp -r LICENSE README.md "$tmp"/.
+cd "$tmp" && cargo publish
 
-rm -rf $tmp
+rm -rf "$tmp"


### PR DESCRIPTION
```
In publish.sh line 3:
tmp=`mktemp -d`
    ^-- SC2006: Use $(..) instead of legacy `..`.

In publish.sh line 5:
echo $tmp
     ^-- SC2086: Double quote to prevent globbing and word splitting.

In publish.sh line 7:
cp -r src $tmp/.
          ^-- SC2086: Double quote to prevent globbing and word
splitting.

In publish.sh line 8:
cp -r LICENSE README.md $tmp/.
                        ^-- SC2086: Double quote to prevent globbing and
word splitting.

In publish.sh line 11:
sed 's#\.\./\.\./src#src#g' build/nphysics2d/Cargo.toml >
$tmp/Cargo.toml
                                                          ^-- SC2086:
Double quote to prevent globbing and word splitting.

In publish.sh line 12:
currdir=`pwd`
        ^-- SC2006: Use $(..) instead of legacy `..`.

In publish.sh line 13:
cd $tmp && cargo publish
   ^-- SC2086: Double quote to prevent globbing and word splitting.

In publish.sh line 14:
cd $currdir
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
   ^-- SC2086: Double quote to prevent globbing and word splitting.

In publish.sh line 18:
sed 's#\.\./\.\./src#src#g' build/nphysics3d/Cargo.toml >
$tmp/Cargo.toml
                                                          ^-- SC2086:
Double quote to prevent globbing and word splitting.

In publish.sh line 19:
cp -r LICENSE README.md $tmp/.
                        ^-- SC2086: Double quote to prevent globbing and
word splitting.

In publish.sh line 20:
cd $tmp && cargo publish
   ^-- SC2086: Double quote to prevent globbing and word splitting.

In publish.sh line 22:
rm -rf $tmp
       ^-- SC2086: Double quote to prevent globbing and word splitting.
```