### PR TITLE
Make `ColliderDesc` derive `Clone`.

### DIFF
--- a/src/object/collider.rs
+++ b/src/object/collider.rs
@@ -341,7 +341,7 @@ pub struct ColliderDesc<N: Real> {
 
 impl<N: Real> ColliderDesc<N> {
     /// Creates a new collider builder with the given shape.
-    pub fn new(shape: ShapeHandle<N>) -> Self {
+    pub fn new(shape: ShapeHandle<N>) -> ColliderDesc<N> {
         let linear_prediction = na::convert(0.001);
         let angular_prediction = na::convert(f64::consts::PI / 180.0 * 5.0);
 


### PR DESCRIPTION
I'm not sure if this is a terrible idea, but this lets me do:

```
struct Body(Vec<ColliderDesc<f32>>);

        // Create my simple Player shape.
        let body_shape = ShapeHandle::new(Ball::new(radius));
        let mut collision_groups = CollisionGroups::new();
        collision_groups.set_membership(&[2]);
        let body_collider = ColliderDesc::new(body_shape)
            .set_collision_groups(collision_groups)
            .clone();
        let body = Body(vec![body_collider]);
```

Then I have a single place in my code that detects when a `Body` component is added, then iterates through the colliders I create and adds them. It probably isn't terribly helpful for more complex use cases, but for my simple case of wanting to model a physical environment and not caring a whole lot about the actual physics, it beats creating a separate struct identical to `ColliderDesc` just so I can copy over the values from something that isn't a reference.

I'm open to deriving `Clone` not being the best solution. Maybe an `.into_owned()` method that returns `self` rather than `&self` or something else. And maybe there's an easy workaround I'm just missing. I mainly wanted to see if this compiled, and when it did, I thought I'd save you a bit of work. :)

Thanks.