### PR TITLE
Disambiguate 2D and 3D crate badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
     <a href="https://discord.gg/vt9DJSW">
         <img src="https://img.shields.io/discord/507548572338880513.svg?logo=discord&colorB=7289DA">
     </a>
-    <a href="https://crates.io/crates/nphysics">
-         <img src="http://meritbadge.herokuapp.com/nphysics3d?style=flat-square" alt="crates.io">
+    <a href="https://crates.io/crates/nphysics2d">
+         <img src="https://img.shields.io/crates/v/nphysics3d.svg?style=flat-square&label=crates.io%20(nphysics2d)" alt="crates.io (nphysics2d)">
+    </a>
+    <a href="https://crates.io/crates/nphysics3d">
+         <img src="https://img.shields.io/crates/v/nphysics3d.svg?style=flat-square&label=crates.io%20(nphysics3d)" alt="crates.io (nphysics3d)">
     </a>
     <a href="https://travis-ci.org/rustsim/nphysics">
         <img src="https://travis-ci.org/rustsim/nphysics.svg?branch=master" alt="Build status">


### PR DESCRIPTION
- The current link for the crate badge leads to an old yanked crate: https://crates.io/crates/nphysics
- I added an extra badge for the 2D crate
- [merit](https://github.com/seanmonstar/merit/blob/master/src/main.rs) doesn't seem to support overriding the label to disambiguate the two crates
- It seems like a direct link to [shields.io](https://shields.io) is working fine for the badges
- I didn't add badges for the testbed crates because I figured it'd be too crowded and those crates aren't used as often
- Same thing applies for [ncollide](https://raw.githubusercontent.com/rustsim/ncollide/master/README.md) (I didn't create a PR yet)