### PR TITLE
Add multithreading

### DIFF
--- a/build/nphysics2d/Cargo.toml
+++ b/build/nphysics2d/Cargo.toml
@@ -31,6 +31,7 @@ approx     = "0.3"
 downcast-rs = "1.0"
 bitflags   = "1.0"
 ncollide2d = "0.19"
+parking_lot = "0.8"
 
 [target.wasm32-unknown-unknown.dependencies]
 stdweb = {version = "0.4", optional = true}

--- a/build/nphysics3d/Cargo.toml
+++ b/build/nphysics3d/Cargo.toml
@@ -31,6 +31,7 @@ approx     = "0.3"
 downcast-rs = "1.0"
 bitflags   = "1.0"
 ncollide3d = "0.19"
+parking_lot = "0.8"
 
 [target.wasm32-unknown-unknown.dependencies]
 stdweb = {version = "0.4", optional = true}

--- a/examples2d/collision_groups2.rs
+++ b/examples2d/collision_groups2.rs
@@ -102,8 +102,7 @@ fn main() {
             let body_handle = RigidBodyDesc::new()
                 .collider(&collider_desc)
                 .translation(Vector2::new(x, y))
-                .build(&mut world)
-                .handle();
+                .build(&mut world);
 
             testbed.set_body_color(body_handle, color);
         }

--- a/examples2d/constraints2.rs
+++ b/examples2d/constraints2.rs
@@ -48,8 +48,9 @@ fn main() {
          */
         let rb_handle = rb_desc
             .set_translation(Vector2::x() * (j + 1) as f32 * rad * 3.0)
-            .build(&mut world)
-            .part_handle();
+            .build(&mut world);
+        
+        let rb_handle = world.rigid_body(rb_handle).unwrap().part_handle();
 
         let revolute_constraint =
             RevoluteConstraint::new(parent, rb_handle, na::origin(), Point2::new(-rad * 3.0, 0.0));
@@ -76,8 +77,9 @@ fn main() {
          */
         let rb_handle = rb_desc
             .set_translation(translation)
-            .build(&mut world)
-            .part_handle();
+            .build(&mut world);
+
+        let rb_handle = world.rigid_body(rb_handle).unwrap().part_handle();
 
         let mut constraint = PrismaticConstraint::new(
             parent,
@@ -115,8 +117,9 @@ fn main() {
 
             let rb_handle = rb_desc
                 .set_translation(shift + Vector2::new(x, y))
-                .build(&mut world)
-                .part_handle();
+                .build(&mut world);
+
+            let rb_handle = world.rigid_body(rb_handle).unwrap().part_handle();
 
             let constraint = CartesianConstraint::new(
                 BodyPartHandle::ground(),

--- a/examples2d/fem_surface2.rs
+++ b/examples2d/fem_surface2.rs
@@ -42,8 +42,7 @@ fn main() {
         .young_modulus(1.0e4)
         .mass_damping(0.2)
         .collider_enabled(true)
-        .build(&mut world)
-        .handle();
+        .build(&mut world);
 
     /*
      * Create a pyramid on top of the deformable body.

--- a/examples2d/force_generator2.rs
+++ b/examples2d/force_generator2.rs
@@ -66,8 +66,9 @@ fn main() {
             // Crate the rigid body and its collider.
             let rb_handle = rb_desc
                 .set_translation(Vector2::new(x, y))
-                .build(&mut world)
-                .part_handle();
+                .build(&mut world);
+
+            let rb_handle = world.rigid_body(rb_handle).unwrap().part_handle();
 
             /*
              * Set artifical gravity.

--- a/examples2d/kinematic2.rs
+++ b/examples2d/kinematic2.rs
@@ -69,8 +69,7 @@ fn main() {
         .translation(Vector2::new(0.0, 1.5))
         .velocity(Velocity::linear(1.0, 0.0))
         .status(BodyStatus::Kinematic)
-        .build(&mut world)
-        .handle();
+        .build(&mut world);
 
     /*
      * Setup a kinematic multibody.
@@ -83,8 +82,11 @@ fn main() {
         .collider(&collider_desc)
         .build(&mut world);
 
-    mb.set_status(BodyStatus::Kinematic);
-    mb.generalized_velocity_mut()[0] = -3.0;
+    {
+        let mut mb_write = world.multibody_mut(mb).unwrap();
+        mb_write.set_status(BodyStatus::Kinematic);
+        mb_write.generalized_velocity_mut()[0] = -3.0;
+    }
 
     /*
      * Setup a motorized multibody.
@@ -108,7 +110,7 @@ fn main() {
     let mut testbed = Testbed::new(world);
     testbed.add_callback(move |world, _, time| {
         let mut world = world.get_mut();
-        if let Some(platform) = world.rigid_body_mut(platform_handle) {
+        if let Some(mut platform) = world.rigid_body_mut(platform_handle) {
             let platform_x = platform.position().translation.vector.x;
 
             let mut vel = *platform.velocity();
@@ -122,7 +124,7 @@ fn main() {
             }
 
             platform.set_velocity(vel);
-        }
+        };
     });
 
     /*

--- a/examples2d/mass_constraint_system2.rs
+++ b/examples2d/mass_constraint_system2.rs
@@ -36,13 +36,14 @@ fn main() {
     /*
      * Create the deformable body and a collider for its boundary.
      */
-    let deformable = MassConstraintSystemDesc::quad(50, 1)
+    let deformable_handle = MassConstraintSystemDesc::quad(50, 1)
         .scale(Vector2::new(10.0, 1.0))
         .translation(Vector2::y() * 1.0)
         .stiffness(Some(1.0e4))
         .collider_enabled(true)
         .build(&mut world);
-    let deformable_handle = deformable.handle();
+
+    let mut deformable = world.mass_constraint_system_mut(deformable_handle).unwrap();
 
     // Add other constraints for volume stiffness.
     deformable.generate_neighbor_constraints(Some(1.0e4));
@@ -55,6 +56,8 @@ fn main() {
     for constraint in extra_constraints1.chain(extra_constraints2) {
         deformable.add_constraint(constraint.x, constraint.y, Some(1.0e4));
     }
+
+    drop(deformable);
 
     /*
      * Create a pyramid on top of the deformable body.

--- a/examples2d/mass_spring_system2.rs
+++ b/examples2d/mass_spring_system2.rs
@@ -36,14 +36,14 @@ fn main() {
     /*
      * Create the deformable body and a collider for its boundary.
      */
-    let deformable = MassSpringSystemDesc::quad(50, 1)
+    let deformable_handle = MassSpringSystemDesc::quad(50, 1)
         .scale(Vector2::new(10.0, 1.0))
         .translation(Vector2::y() * 1.0)
         .stiffness(1.0e3)
         .damping_ratio(0.2)
         .collider_enabled(true)
         .build(&mut world);
-    let deformable_handle = deformable.handle();
+    let mut deformable = world.mass_spring_system_mut(deformable_handle).unwrap();
 
     // Add other springs for volume stiffness.
     deformable.generate_neighbor_springs(1.0e3, 0.5);
@@ -56,6 +56,8 @@ fn main() {
     for spring in extra_springs1.chain(extra_springs2) {
         deformable.add_spring(spring.x, spring.y, 1.0e3, 0.5);
     }
+
+    drop(deformable);
 
     /*
      * Create a pyramid on top of the deformable body.

--- a/examples2d/plasticity2.rs
+++ b/examples2d/plasticity2.rs
@@ -38,8 +38,7 @@ fn main() {
             .position(*pos)
             .status(BodyStatus::Kinematic)
             .collider(&ColliderDesc::new(platform_shape.clone()))
-            .build(&mut world)
-            .handle();
+            .build(&mut world);
     }
 
     /*
@@ -52,8 +51,7 @@ fn main() {
         .mass_damping(0.2)
         .plasticity(0.1, 5.0, 10.0)
         .collider_enabled(true)
-        .build(&mut world)
-        .handle();
+        .build(&mut world);
 
     /*
      * Set up the testbed.
@@ -68,7 +66,7 @@ fn main() {
     testbed.add_callback(move |world, _, _| {
         let mut world = world.get_mut();
         for (i, handle) in platforms.iter().enumerate() {
-            let platform = world.rigid_body_mut(*handle).unwrap();
+            let mut platform = world.rigid_body_mut(*handle).unwrap();
             let platform_y = platform.position().translation.vector.y;
 
             let mut vel = *platform.velocity();

--- a/examples2d/sensor2.rs
+++ b/examples2d/sensor2.rs
@@ -53,8 +53,7 @@ fn main() {
         // Build the rigid body and its collider.
         let handle = rb_desc
             .set_translation(Vector2::new(x, 2.0))
-            .build(&mut world)
-            .handle();
+            .build(&mut world);
 
         testbed.set_body_color(handle, Point3::new(0.5, 0.5, 1.0));
     }
@@ -73,8 +72,7 @@ fn main() {
         .collider(&collider_desc)
         .collider(&sensor_collider)
         .translation(Vector2::new(0.0, 4.0))
-        .build(&mut world)
-        .handle();
+        .build(&mut world);
 
     testbed.set_body_color(sensor_body, Point3::new(0.5, 1.0, 1.0));
 

--- a/examples3d/collision_groups3.rs
+++ b/examples3d/collision_groups3.rs
@@ -101,8 +101,7 @@ fn main() {
                 let body_handle = RigidBodyDesc::new()
                     .collider(&collider_desc)
                     .translation(Vector3::new(x, y, z))
-                    .build(&mut world)
-                    .handle();
+                    .build(&mut world);
 
                 testbed.set_body_color(body_handle, color);
             }

--- a/examples3d/constraints3.rs
+++ b/examples3d/constraints3.rs
@@ -64,8 +64,9 @@ fn main() {
 
         let rb_handle = rb_desc
             .set_translation(pos)
-            .build(&mut world)
-            .part_handle();
+            .build(&mut world);
+
+        let rb_handle = world.rigid_body(rb_handle).unwrap().part_handle();
 
         let constraint = RevoluteConstraint::new(
             parent,
@@ -101,8 +102,9 @@ fn main() {
 
         let rb_handle = rb_desc
             .set_translation(pos)
-            .build(&mut world)
-            .part_handle();
+            .build(&mut world);
+
+        let rb_handle = world.rigid_body(rb_handle).unwrap().part_handle();
 
         let mut constraint =
             PrismaticConstraint::new(parent, rb_handle, parent_anchor, Vector3::y_axis(), body_anchor);
@@ -135,8 +137,9 @@ fn main() {
 
         let rb_handle = rb_desc
             .set_translation(pos)
-            .build(&mut world)
-            .part_handle();
+            .build(&mut world);
+
+        let rb_handle = world.rigid_body(rb_handle).unwrap().part_handle();
 
         let constraint = BallConstraint::new(parent, rb_handle, parent_anchor, body_anchor);
         world.add_constraint(constraint);
@@ -155,8 +158,9 @@ fn main() {
 
     let rb_handle = rb_desc
         .set_translation(child_pos)
-        .build(&mut world)
-        .part_handle();
+        .build(&mut world);
+
+    let rb_handle = world.rigid_body(rb_handle).unwrap().part_handle();
 
     let constraint = UniversalConstraint::new(
         BodyPartHandle::ground(),
@@ -188,8 +192,9 @@ fn main() {
 
             let rb_handle = rb_desc
                 .set_translation(shift + Vector3::new(0.0, y, z))
-                .build(&mut world)
-                .part_handle();
+                .build(&mut world);
+
+            let rb_handle = world.rigid_body(rb_handle).unwrap().part_handle();
 
             let constraint = PlanarConstraint::new(
                 BodyPartHandle::ground(),
@@ -220,8 +225,9 @@ fn main() {
 
             let rb_handle = rb_desc
                 .set_translation(shift + Vector3::new(0.0, y, z))
-                .build(&mut world)
-                .part_handle();
+                .build(&mut world);
+            
+            let rb_handle = world.rigid_body(rb_handle).unwrap().part_handle();
 
             let constraint = RectangularConstraint::new(
                 BodyPartHandle::ground(),
@@ -244,8 +250,9 @@ fn main() {
 
     let pin_handle = RigidBodyDesc::new()
         .collider(&collider_desc)
-        .build(&mut world)
-        .part_handle();
+        .build(&mut world);
+    
+    let pin_handle = world.rigid_body(pin_handle).unwrap().part_handle();
 
     let constraint = PinSlotConstraint::new(
         BodyPartHandle::ground(),

--- a/examples3d/fixed_bug_tree_like_multibody3.rs
+++ b/examples3d/fixed_bug_tree_like_multibody3.rs
@@ -21,7 +21,6 @@ fn new_link<J: Joint<f32>>(world: &mut World<f32>, joint: J, parent: BodyPartHan
         .collider(&collider_desc)
         .build_with_parent(parent, world)
         .unwrap()
-        .part_handle()
 }
 
 fn main() {

--- a/examples3d/force_generator3.rs
+++ b/examples3d/force_generator3.rs
@@ -63,8 +63,9 @@ fn main() {
                 // Build the rigid body and its collider.
                 let rb_handle = rb_desc
                     .set_translation(Vector3::new(x, y, z))
-                    .build(&mut world)
-                    .part_handle();
+                    .build(&mut world);
+                
+                let rb_handle = world.rigid_body(rb_handle).unwrap().part_handle();
 
                 /*
                  * Set artificial gravity.

--- a/examples3d/kinematic3.rs
+++ b/examples3d/kinematic3.rs
@@ -74,22 +74,24 @@ fn main() {
         .collider(&collider_desc)
         .translation(Vector3::new(0.0, 1.5 + 0.8, -10.0 * rad))
         .status(BodyStatus::Kinematic)
-        .build(&mut world)
-        .handle();
+        .build(&mut world);
 
     /*
      * Setup a kinematic multibody.
      */
     let joint = RevoluteJoint::new(Vector3::x_axis(), 0.0);
 
-    let mb = MultibodyDesc::new(joint)
+    let mb_handle = MultibodyDesc::new(joint)
         .body_shift(Vector3::z() * 2.0)
         .parent_shift(Vector3::new(0.0, 2.0, 5.0))
         .collider(&small_cuboid_collider_desc)
         .build(&mut world);
 
-    mb.set_status(BodyStatus::Kinematic);
-    mb.generalized_velocity_mut()[0] = 3.0;
+    {
+        let mut mb = world.multibody_mut(mb_handle).unwrap();
+        mb.set_status(BodyStatus::Kinematic);
+        mb.generalized_velocity_mut()[0] = 3.0;
+    }
 
     /*
      * Setup a motorized multibody.
@@ -112,7 +114,7 @@ fn main() {
 
     testbed.add_callback(move |world, _, time| {
         let mut world = world.get_mut();
-        let platform = world.rigid_body_mut(platform_handle).unwrap();
+        let mut platform = world.rigid_body_mut(platform_handle).unwrap();
         let platform_z = platform.position().translation.z;
 
         let mut vel = *platform.velocity();

--- a/examples3d/mass_constraint_system3.rs
+++ b/examples3d/mass_constraint_system3.rs
@@ -56,14 +56,18 @@ fn main() {
             .stiffness(Some(0.1))
             .collider_enabled(true);
 
-        let deformable1 = desc.build(&mut world);
-        deformable1.generate_neighbor_constraints(Some(0.1));
-        deformable1.generate_neighbor_constraints(Some(0.1));
+        {
+            let deformable1_handle = desc.build(&mut world);
+            let mut deformable1 = world.mass_constraint_system_mut(deformable1_handle).unwrap();
+            deformable1.generate_neighbor_constraints(Some(0.1));
+            deformable1.generate_neighbor_constraints(Some(0.1));
+        }
 
-        let deformable2 = desc
+        let deformable2_handle = desc
             .set_position(Isometry3::new(Vector3::y() * 9.5, rot))
             .set_stiffness(Some(100.0))
             .build(&mut world);
+        let mut deformable2 = world.mass_constraint_system_mut(deformable2_handle).unwrap();    
         deformable2.generate_neighbor_constraints(Some(100.0));
         deformable2.generate_neighbor_constraints(Some(100.0));
     }

--- a/examples3d/mass_spring_system3.rs
+++ b/examples3d/mass_spring_system3.rs
@@ -57,14 +57,18 @@ fn main() {
             .damping_ratio(0.2)
             .collider_enabled(true);
 
-        let deformable1 = desc.build(&mut world);
-        deformable1.generate_neighbor_springs(10.0, 0.5);
-        deformable1.generate_neighbor_springs(10.0, 0.5);
+        {
+            let deformable1_handle = desc.build(&mut world);
+            let mut deformable1 = world.mass_spring_system_mut(deformable1_handle).unwrap();
+            deformable1.generate_neighbor_springs(10.0, 0.5);
+            deformable1.generate_neighbor_springs(10.0, 0.5);
+        }
 
-        let deformable2 = desc
+        let deformable2_handle = desc
             .set_position(Isometry3::new(Vector3::y() * 9.5, rot))
             .set_stiffness(100.0)
             .build(&mut world);
+        let mut deformable2 = world.mass_spring_system_mut(deformable2_handle).unwrap();
         deformable2.generate_neighbor_springs(100.0, 0.5);
         deformable2.generate_neighbor_springs(100.0, 0.5);
     }

--- a/examples3d/multibody3.rs
+++ b/examples3d/multibody3.rs
@@ -119,8 +119,12 @@ fn main() {
         .add_collider(&collider);
 
     // Remove the default damping so that it balances indefinitely.
-    let mb = multibody.build(&mut world);
-    mb.damping_mut().fill(0.0);
+    let mb_handle = multibody.build(&mut world);
+
+    {
+        let mut mb_write = world.multibody_mut(mb_handle).unwrap();
+        mb_write.damping_mut().fill(0.0);
+    }
 
     /*
      * Helical joint.
@@ -134,8 +138,7 @@ fn main() {
     let helical_handle = MultibodyDesc::new(hel)
         .parent_shift(parent_shift)
         .collider(&collider)
-        .build(&mut world)
-        .handle();
+        .build(&mut world);
 
     /*
      * Planar joint.
@@ -209,8 +212,7 @@ fn main() {
     let pin_slot_handle = MultibodyDesc::new(pin_slot)
         .parent_shift(shift)
         .collider(&collider)
-        .build(&mut world)
-        .handle();
+        .build(&mut world);
 
     /*
      * Set up the testbed.
@@ -224,7 +226,11 @@ fn main() {
          */
         // Might be None if the user interactively deleted the helical body.
         let mut world = world.get_mut();
-        let link = world.multibody_mut(helical_handle).and_then(|mb| mb.link_mut(0));
+        let mut mb;
+        let mut link = None;
+        let mb_option = world.multibody_mut(helical_handle);
+        if mb_option.is_some() { mb = mb_option.unwrap(); link = mb.link_mut(0) }
+
         if let Some(helical) = link {
             let dof = helical
                 .joint_mut()
@@ -245,7 +251,11 @@ fn main() {
          */
         // Might be None if the user interactively deleted the pin-slot body.
         let mut world = world.get_mut();
-        let link = world.multibody_mut(pin_slot_handle).and_then(|mb| mb.link_mut(0));
+        let mut mb;
+        let mut link = None;
+        let mb_option = world.multibody_mut(pin_slot_handle);
+        if mb_option.is_some() { mb = mb_option.unwrap(); link = mb.link_mut(0) }
+
         if let Some(pin_slot) = link {
             let dof = pin_slot
                 .joint_mut()

--- a/examples3d/plasticity3.rs
+++ b/examples3d/plasticity3.rs
@@ -39,8 +39,7 @@ fn main() {
             .position(*pos)
             .status(BodyStatus::Kinematic)
             .collider(&ColliderDesc::new(platform_shape.clone()))
-            .build(&mut world)
-            .handle();
+            .build(&mut world);
     }
 
     /*
@@ -68,7 +67,7 @@ fn main() {
     testbed.add_callback(move |world, _, _| {
         let mut world = world.get_mut();
         for (i, handle) in platforms.iter().enumerate() {
-            let platform = world.rigid_body_mut(*handle).unwrap();
+            let mut platform = world.rigid_body_mut(*handle).unwrap();
             let platform_y = platform.position().translation.vector.y;
 
             let mut vel = *platform.velocity();

--- a/examples3d/sensor3.rs
+++ b/examples3d/sensor3.rs
@@ -56,8 +56,7 @@ fn main() {
             // Build the rigid body and its collider.
             let handle = rb_desc
                 .set_translation(Vector3::new(x, 3.0, z))
-                .build(&mut world)
-                .handle();
+                .build(&mut world);
             testbed.set_body_color(handle, Point3::new(0.5, 0.5, 1.0));
         }
     }
@@ -75,8 +74,7 @@ fn main() {
         .collider(&collider_desc)
         .collider(&sensor_collider)
         .translation(Vector3::new(0.0, 10.0, 0.0))
-        .build(&mut world)
-        .handle();
+        .build(&mut world);
 
     testbed.set_body_color(sensor_handle, Point3::new(0.5, 1.0, 1.0));
 

--- a/src/detection/activation_manager.rs
+++ b/src/detection/activation_manager.rs
@@ -73,10 +73,10 @@ impl<N: RealField> ActivationManager<N> {
          */
         self.id_to_body.clear();
 
-        for body in bodies.bodies_mut() {
+        for mut body in bodies.bodies_mut() {
             if body.status_dependent_ndofs() != 0 {
                 if body.is_active() {
-                    self.update_energy(body);
+                    self.update_energy(&mut *body);
                 }
 
                 body.set_companion_id(self.id_to_body.len());
@@ -95,7 +95,7 @@ impl<N: RealField> ActivationManager<N> {
          *
          */
         for handle in self.to_activate.iter() {
-            let body = try_continue!(bodies.body_mut(*handle));
+            let mut body = try_continue!(bodies.body_mut(*handle));
 
             if body.activation_status().deactivation_threshold().is_some() {
                 body.activate()
@@ -174,7 +174,7 @@ impl<N: RealField> ActivationManager<N> {
         for i in 0usize..self.ufind.len() {
             let root = union_find::find(i, &mut self.ufind[..]);
             let handle = self.id_to_body[i];
-            let body = try_continue!(bodies.body_mut(handle));
+            let mut body = try_continue!(bodies.body_mut(handle));
 
             if self.can_deactivate[root] {
                 // Everybody in this set can be deactivacted.

--- a/src/force_generator/constant_acceleration.rs
+++ b/src/force_generator/constant_acceleration.rs
@@ -45,7 +45,7 @@ impl<N: RealField> ForceGenerator<N> for ConstantAcceleration<N> {
     fn apply(&mut self, _: &IntegrationParameters<N>, bodies: &mut BodySet<N>) -> bool {
         let acceleration = self.acceleration;
         self.parts.retain(|h| {
-            if let Some(body) = bodies.body_mut(h.0) {
+            if let Some(mut body) = bodies.body_mut(h.0) {
                 body.apply_force(h.1,
                                  &Force::new(acceleration.linear, acceleration.angular),
                                  ForceType::AccelerationChange,

--- a/src/force_generator/spring.rs
+++ b/src/force_generator/spring.rs
@@ -78,6 +78,9 @@ impl<N: RealField> ForceGenerator<N> for Spring<N> {
             delta_length = -self.length;
         }
 
+        drop(body1);
+        drop(body2);
+        
         let force = force_dir.as_ref() * delta_length * self.stiffness;
         bodies.body_mut(self.b1.0).unwrap().apply_force_at_local_point(self.b1.1, &force, &self.anchor1, ForceType::Force, false);
         bodies.body_mut(self.b2.0).unwrap().apply_force_at_local_point(self.b2.1, &-force, &self.anchor2, ForceType::Force, false);

--- a/src/joint/ball_constraint.rs
+++ b/src/joint/ball_constraint.rs
@@ -66,8 +66,8 @@ impl<N: RealField> JointConstraint<N> for BallConstraint<N> {
         jacobians: &mut [N],
         constraints: &mut ConstraintSet<N>,
     ) {
-        let body1 = try_ret!(bodies.body(self.b1.0));
-        let body2 = try_ret!(bodies.body(self.b2.0));
+        let body1 = &*try_ret!(bodies.body(self.b1.0));
+        let body2 = &*try_ret!(bodies.body(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));
         let part2 = try_ret!(body2.part(self.b2.1));
 
@@ -136,8 +136,8 @@ impl<N: RealField> NonlinearConstraintGenerator<N> for BallConstraint<N> {
         bodies: &mut BodySet<N>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N>> {
-        let body1 = bodies.body(self.b1.0)?;
-        let body2 = bodies.body(self.b2.0)?;
+        let body1 = &*bodies.body(self.b1.0)?;
+        let body2 = &*bodies.body(self.b2.0)?;
         let part1 = body1.part(self.b1.1)?;
         let part2 = body2.part(self.b2.1)?;
 

--- a/src/joint/cartesian_constraint.rs
+++ b/src/joint/cartesian_constraint.rs
@@ -87,8 +87,8 @@ impl<N: RealField> JointConstraint<N> for CartesianConstraint<N> {
         jacobians: &mut [N],
         constraints: &mut ConstraintSet<N>,
     ) {
-        let body1 = try_ret!(bodies.body(self.b1.0));
-        let body2 = try_ret!(bodies.body(self.b2.0));
+        let body1 = &*try_ret!(bodies.body(self.b1.0));
+        let body2 = &*try_ret!(bodies.body(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));
         let part2 = try_ret!(body2.part(self.b2.1));
 
@@ -155,8 +155,8 @@ impl<N: RealField> NonlinearConstraintGenerator<N> for CartesianConstraint<N> {
         bodies: &mut BodySet<N>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N>> {
-        let body1 = bodies.body(self.b1.0)?;
-        let body2 = bodies.body(self.b2.0)?;
+        let body1 = &*bodies.body(self.b1.0)?;
+        let body2 = &*bodies.body(self.b2.0)?;
         let part1 = body1.part(self.b1.1)?;
         let part2 = body2.part(self.b2.1)?;
 

--- a/src/joint/cylindrical_constraint.rs
+++ b/src/joint/cylindrical_constraint.rs
@@ -111,8 +111,8 @@ impl<N: RealField> JointConstraint<N> for CylindricalConstraint<N> {
         jacobians: &mut [N],
         constraints: &mut ConstraintSet<N>,
     ) {
-        let body1 = try_ret!(bodies.body(self.b1.0));
-        let body2 = try_ret!(bodies.body(self.b2.0));
+        let body1 = &*try_ret!(bodies.body(self.b1.0));
+        let body2 = &*try_ret!(bodies.body(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));
         let part2 = try_ret!(body2.part(self.b2.1));
 
@@ -220,8 +220,8 @@ impl<N: RealField> NonlinearConstraintGenerator<N> for CylindricalConstraint<N> 
         bodies: &mut BodySet<N>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N>> {
-        let body1 = bodies.body(self.b1.0)?;
-        let body2 = bodies.body(self.b2.0)?;
+        let body1 = &*bodies.body(self.b1.0)?;
+        let body2 = &*bodies.body(self.b2.0)?;
         let part1 = body1.part(self.b1.1)?;
         let part2 = body2.part(self.b2.1)?;
 

--- a/src/joint/fixed_constraint.rs
+++ b/src/joint/fixed_constraint.rs
@@ -89,8 +89,8 @@ impl<N: RealField> JointConstraint<N> for FixedConstraint<N> {
         jacobians: &mut [N],
         constraints: &mut ConstraintSet<N>,
     ) {
-        let body1 = try_ret!(bodies.body(self.b1.0));
-        let body2 = try_ret!(bodies.body(self.b2.0));
+        let body1 = &*try_ret!(bodies.body(self.b1.0));
+        let body2 = &*try_ret!(bodies.body(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));
         let part2 = try_ret!(body2.part(self.b2.1));
 
@@ -183,8 +183,8 @@ impl<N: RealField> NonlinearConstraintGenerator<N> for FixedConstraint<N> {
         bodies: &mut BodySet<N>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N>> {
-        let body1 = bodies.body(self.b1.0)?;
-        let body2 = bodies.body(self.b2.0)?;
+        let body1 = &*bodies.body(self.b1.0)?;
+        let body2 = &*bodies.body(self.b2.0)?;
         let part1 = body1.part(self.b1.1)?;
         let part2 = body2.part(self.b2.1)?;
 

--- a/src/joint/mouse_constraint.rs
+++ b/src/joint/mouse_constraint.rs
@@ -68,8 +68,8 @@ impl<N: RealField> JointConstraint<N> for MouseConstraint<N> {
         jacobians: &mut [N],
         constraints: &mut ConstraintSet<N>,
     ) {
-        let body1 = try_ret!(bodies.body(self.b1.0));
-        let body2 = try_ret!(bodies.body(self.b2.0));
+        let body1 = &*try_ret!(bodies.body(self.b1.0));
+        let body2 = &*try_ret!(bodies.body(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));
         let part2 = try_ret!(body2.part(self.b2.1));
 

--- a/src/joint/pin_slot_constraint.rs
+++ b/src/joint/pin_slot_constraint.rs
@@ -118,8 +118,8 @@ impl<N: RealField> JointConstraint<N> for PinSlotConstraint<N> {
         jacobians: &mut [N],
         constraints: &mut ConstraintSet<N>,
     ) {
-        let body1 = try_ret!(bodies.body(self.b1.0));
-        let body2 = try_ret!(bodies.body(self.b2.0));
+        let body1 = &*try_ret!(bodies.body(self.b1.0));
+        let body2 = &*try_ret!(bodies.body(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));
         let part2 = try_ret!(body2.part(self.b2.1));
 
@@ -228,8 +228,8 @@ impl<N: RealField> NonlinearConstraintGenerator<N> for PinSlotConstraint<N> {
         bodies: &mut BodySet<N>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N>> {
-        let body1 = bodies.body(self.b1.0)?;
-        let body2 = bodies.body(self.b2.0)?;
+        let body1 = &*bodies.body(self.b1.0)?;
+        let body2 = &*bodies.body(self.b2.0)?;
         let part1 = body1.part(self.b1.1)?;
         let part2 = body2.part(self.b2.1)?;
 

--- a/src/joint/planar_constraint.rs
+++ b/src/joint/planar_constraint.rs
@@ -70,8 +70,8 @@ impl<N: RealField> JointConstraint<N> for PlanarConstraint<N> {
         jacobians: &mut [N],
         constraints: &mut ConstraintSet<N>,
     ) {
-        let body1 = try_ret!(bodies.body(self.b1.0));
-        let body2 = try_ret!(bodies.body(self.b2.0));
+        let body1 = &*try_ret!(bodies.body(self.b1.0));
+        let body2 = &*try_ret!(bodies.body(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));
         let part2 = try_ret!(body2.part(self.b2.1));
 
@@ -179,8 +179,8 @@ impl<N: RealField> NonlinearConstraintGenerator<N> for PlanarConstraint<N> {
         bodies: &mut BodySet<N>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N>> {
-        let body1 = bodies.body(self.b1.0)?;
-        let body2 = bodies.body(self.b2.0)?;
+        let body1 = &*bodies.body(self.b1.0)?;
+        let body2 = &*bodies.body(self.b2.0)?;
         let part1 = body1.part(self.b1.1)?;
         let part2 = body2.part(self.b2.1)?;
 

--- a/src/joint/prismatic_constraint.rs
+++ b/src/joint/prismatic_constraint.rs
@@ -115,8 +115,8 @@ impl<N: RealField> JointConstraint<N> for PrismaticConstraint<N> {
         jacobians: &mut [N],
         constraints: &mut ConstraintSet<N>,
     ) {
-        let body1 = try_ret!(bodies.body(self.b1.0));
-        let body2 = try_ret!(bodies.body(self.b2.0));
+        let body1 = &*try_ret!(bodies.body(self.b1.0));
+        let body2 = &*try_ret!(bodies.body(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));
         let part2 = try_ret!(body2.part(self.b2.1));
 
@@ -251,8 +251,8 @@ impl<N: RealField> NonlinearConstraintGenerator<N> for PrismaticConstraint<N> {
         bodies: &mut BodySet<N>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N>> {
-        let body1 = bodies.body(self.b1.0)?;
-        let body2 = bodies.body(self.b2.0)?;
+        let body1 = &*bodies.body(self.b1.0)?;
+        let body2 = &*bodies.body(self.b2.0)?;
         let part1 = body1.part(self.b1.1)?;
         let part2 = body2.part(self.b2.1)?;
 

--- a/src/joint/rectangular_constraint.rs
+++ b/src/joint/rectangular_constraint.rs
@@ -66,8 +66,8 @@ impl<N: RealField> JointConstraint<N> for RectangularConstraint<N> {
         jacobians: &mut [N],
         constraints: &mut ConstraintSet<N>,
     ) {
-        let body1 = try_ret!(bodies.body(self.b1.0));
-        let body2 = try_ret!(bodies.body(self.b2.0));
+        let body1 = &*try_ret!(bodies.body(self.b1.0));
+        let body2 = &*try_ret!(bodies.body(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));
         let part2 = try_ret!(body2.part(self.b2.1));
 
@@ -174,8 +174,8 @@ impl<N: RealField> NonlinearConstraintGenerator<N> for RectangularConstraint<N> 
         bodies: &mut BodySet<N>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N>> {
-        let body1 = bodies.body(self.b1.0)?;
-        let body2 = bodies.body(self.b2.0)?;
+        let body1 = &*bodies.body(self.b1.0)?;
+        let body2 = &*bodies.body(self.b2.0)?;
         let part1 = body1.part(self.b1.1)?;
         let part2 = body2.part(self.b2.1)?;
 

--- a/src/joint/revolute_constraint.rs
+++ b/src/joint/revolute_constraint.rs
@@ -150,8 +150,8 @@ impl<N: RealField> JointConstraint<N> for RevoluteConstraint<N> {
         jacobians: &mut [N],
         constraints: &mut ConstraintSet<N>,
     ) {
-        let body1 = try_ret!(bodies.body(self.b1.0));
-        let body2 = try_ret!(bodies.body(self.b2.0));
+        let body1 = &*try_ret!(bodies.body(self.b1.0));
+        let body2 = &*try_ret!(bodies.body(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));
         let part2 = try_ret!(body2.part(self.b2.1));
 
@@ -265,8 +265,8 @@ impl<N: RealField> NonlinearConstraintGenerator<N> for RevoluteConstraint<N> {
         bodies: &mut BodySet<N>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N>> {
-        let body1 = bodies.body(self.b1.0)?;
-        let body2 = bodies.body(self.b2.0)?;
+        let body1 = &*bodies.body(self.b1.0)?;
+        let body2 = &*bodies.body(self.b2.0)?;
         let part1 = body1.part(self.b1.1)?;
         let part2 = body2.part(self.b2.1)?;
 

--- a/src/joint/universal_constraint.rs
+++ b/src/joint/universal_constraint.rs
@@ -71,8 +71,8 @@ impl<N: RealField> JointConstraint<N> for UniversalConstraint<N> {
         jacobians: &mut [N],
         constraints: &mut ConstraintSet<N>,
     ) {
-        let body1 = try_ret!(bodies.body(self.b1.0));
-        let body2 = try_ret!(bodies.body(self.b2.0));
+        let body1 = &*try_ret!(bodies.body(self.b1.0));
+        let body2 = &*try_ret!(bodies.body(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));
         let part2 = try_ret!(body2.part(self.b2.1));
 
@@ -181,8 +181,8 @@ impl<N: RealField> NonlinearConstraintGenerator<N> for UniversalConstraint<N> {
         bodies: &mut BodySet<N>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N>> {
-        let body1 = bodies.body(self.b1.0)?;
-        let body2 = bodies.body(self.b2.0)?;
+        let body1 = &*bodies.body(self.b1.0)?;
+        let body2 = &*bodies.body(self.b2.0)?;
         let part1 = body1.part(self.b1.1)?;
         let part2 = body2.part(self.b2.1)?;
 

--- a/src/object/body.rs
+++ b/src/object/body.rs
@@ -319,6 +319,10 @@ pub trait Body<N: RealField>: Downcast + Send + Sync {
 
     /// Apply a local force at a given local point of a part of this body.
     fn apply_local_force_at_local_point(&mut self, part_id: usize, force: &Vector<N>, point: &Point<N>, force_type: ForceType, auto_wake_up: bool);
+
+    fn push_to_buffer(&mut self);
+
+    fn update_from_buffer(&mut self);
 }
 
 /// Trait implemented by each part of a body supported by nphysics.

--- a/src/object/collider.rs
+++ b/src/object/collider.rs
@@ -434,7 +434,7 @@ impl<N: RealField> ColliderDesc<N> {
 
     fn do_build<'w>(&self, parent: BodyPartHandle, world: &'w mut World<N>) -> Option<&'w mut Collider<N>> {
         let (bodies, cworld) = world.bodies_mut_and_collider_world_mut();
-        let body = bodies.body_mut(parent.0)?;
+        let body = &mut *bodies.body_mut(parent.0)?;
         self.build_with_infos(parent, body, cworld)
     }
 
@@ -568,7 +568,7 @@ impl<N: RealField> DeformableColliderDesc<N> {
     /// Builds a deformable collider attached to `parent` into the `world`.
     pub fn build_parent<'w>(&self, parent: BodyHandle, world: &'w mut World<N>) -> Option<&'w mut Collider<N>> {
         let (bodies, cworld) = world.bodies_mut_and_collider_world_mut();
-        let parent = bodies.body(parent)?;
+        let parent = &*bodies.body(parent)?;
         Some(self.build_with_infos(parent, cworld))
     }
 

--- a/src/object/fem_surface.rs
+++ b/src/object/fem_surface.rs
@@ -928,6 +928,12 @@ impl<N: RealField> Body<N> for FEMSurface<N> {
         let world_force = self.elements[part_id].rot * force;
         self.apply_force_at_local_point(part_id, &world_force, &point, force_type, auto_wake_up);
     }
+
+    #[inline]
+    fn push_to_buffer(&mut self) {}
+    
+    #[inline]
+    fn update_from_buffer(&mut self) {}
 }
 
 
@@ -1068,7 +1074,7 @@ impl<'a, N: RealField> FEMSurfaceDesc<'a, N> {
     );
 
     /// Build a deformable surface.
-    pub fn build<'w>(&self, world: &'w mut World<N>) -> &'w mut FEMSurface<N> {
+    pub fn build<'w>(&self, world: &'w mut World<N>) -> BodyHandle {
         world.add_body(self)
     }
 }

--- a/src/object/fem_volume.rs
+++ b/src/object/fem_volume.rs
@@ -991,6 +991,12 @@ impl<N: RealField> Body<N> for FEMVolume<N> {
         let world_force = self.elements[part_id].rot * force;
         self.apply_force_at_local_point(part_id, &world_force, &point, force_type, auto_wake_up);
     }
+
+    #[inline]
+    fn push_to_buffer(&mut self) {}
+
+    #[inline]
+    fn update_from_buffer(&mut self) {}
 }
 
 
@@ -1130,7 +1136,7 @@ impl<'a, N: RealField> FEMVolumeDesc<'a, N> {
     );
 
     /// Build a deformable volume.
-    pub fn build<'w>(&self, world: &'w mut World<N>) -> &'w mut FEMVolume<N> {
+    pub fn build<'w>(&self, world: &'w mut World<N>) -> BodyHandle {
         world.add_body(self)
     }
 }

--- a/src/object/ground.rs
+++ b/src/object/ground.rs
@@ -238,6 +238,12 @@ impl<N: RealField> Body<N> for Ground<N> {
 
     #[inline]
     fn apply_local_force_at_local_point(&mut self, _: usize, _: &Vector<N>, _: &Point<N>, _: ForceType, _: bool) {}
+
+    #[inline]
+    fn push_to_buffer(&mut self) {}
+
+    #[inline]
+    fn update_from_buffer(&mut self) {}
 }
 
 impl<N: RealField> BodyPart<N> for Ground<N> {

--- a/src/object/mass_constraint_system.rs
+++ b/src/object/mass_constraint_system.rs
@@ -782,6 +782,12 @@ impl<N: RealField> Body<N> for MassConstraintSystem<N> {
         // FIXME: compute an approximate rotation for the conserned element (just like the FEM bodies)?
         self.apply_force_at_local_point(part_id, &force, &point, force_type, auto_wake_up);
     }
+
+    #[inline]
+    fn push_to_buffer(&mut self) {}
+
+    #[inline]
+    fn update_from_buffer(&mut self) {}
 }
 
 
@@ -924,7 +930,7 @@ impl<'a, N: RealField> MassConstraintSystemDesc<'a, N> {
     );
 
     /// Build a mass-constraint system.
-    pub fn build<'w>(&self, world: &'w mut World<N>) -> &'w mut MassConstraintSystem<N> {
+    pub fn build<'w>(&self, world: &'w mut World<N>) -> BodyHandle {
         world.add_body(self)
     }
 }

--- a/src/object/mass_spring_system.rs
+++ b/src/object/mass_spring_system.rs
@@ -767,6 +767,12 @@ impl<N: RealField> Body<N> for MassSpringSystem<N> {
         // FIXME: compute an approximate rotation for the conserned element (just like the FEM bodies)?
         self.apply_force_at_local_point(part_id, &force, &point, force_type, auto_wake_up);
     }
+
+    #[inline]
+    fn push_to_buffer(&mut self) {}
+    
+    #[inline]
+    fn update_from_buffer(&mut self) {}
 }
 
 
@@ -907,7 +913,7 @@ impl<'a, N: RealField> MassSpringSystemDesc<'a, N> {
     );
 
     /// Builds a mass-spring system.
-    pub fn build<'w>(&self, world: &'w mut World<N>) -> &'w mut MassSpringSystem<N> {
+    pub fn build<'w>(&self, world: &'w mut World<N>) -> BodyHandle {
         world.add_body(self)
     }
 }

--- a/src/object/rigid_body.rs
+++ b/src/object/rigid_body.rs
@@ -42,6 +42,7 @@ pub struct RigidBody<N: RealField> {
 
 impl<N: RealField> RigidBody<N> {
     /// Create a new rigid body with the specified handle and dynamic properties.
+
     fn new(handle: BodyHandle, position: Isometry<N>) -> Self {
         let inertia = Inertia::zero();
         let com = Point::from(position.translation.vector);
@@ -658,6 +659,12 @@ impl<N: RealField> Body<N> for RigidBody<N> {
     fn apply_local_force_at_local_point(&mut self, _: usize, force: &Vector<N>, point: &Point<N>, force_type: ForceType, auto_wake_up: bool) {
         self.apply_force_at_point(0, &(self.position * force), &(self.position * point), force_type, auto_wake_up)
     }
+
+    #[inline]
+    fn push_to_buffer(&mut self) {}
+    
+    #[inline]
+    fn update_from_buffer(&mut self) {}
 }
 
 
@@ -821,7 +828,7 @@ impl<'a, N: RealField> RigidBodyDesc<'a, N> {
     );
 
     /// Builds a rigid body and all its attached colliders.
-    pub fn build<'w>(&mut self, world: &'w mut World<N>) -> &'w mut RigidBody<N> {
+    pub fn build<'w>(&mut self, world: &'w mut World<N>) -> BodyHandle {
         world.add_body(self)
     }
 }

--- a/src/solver/moreau_jean_solver.rs
+++ b/src/solver/moreau_jean_solver.rs
@@ -87,7 +87,7 @@ impl<N: RealField> MoreauJeanSolver<N> {
         let mut system_ndofs = 0;
 
         for handle in island {
-            let body = try_continue!(bodies.body_mut(*handle));
+            let mut body = try_continue!(bodies.body_mut(*handle));
             body.set_companion_id(system_ndofs);
             let ndofs = body.status_dependent_ndofs();
             assert!(
@@ -199,7 +199,7 @@ impl<N: RealField> MoreauJeanSolver<N> {
 
 
         for handle in &self.internal_constraints {
-            if let Some(body) = bodies.body_mut(*handle) {
+            if let Some(mut body) = bodies.body_mut(*handle) {
                 let ext_vels = self.ext_vels.rows(body.companion_id(), body.ndofs());
                 body.setup_internal_velocity_constraints(&ext_vels, params);
             }
@@ -266,7 +266,7 @@ impl<N: RealField> MoreauJeanSolver<N> {
         island: &[BodyHandle],
     ) {
         for handle in island {
-            let body = try_continue!(bodies.body_mut(*handle));
+            let mut body = try_continue!(bodies.body_mut(*handle));
             let id = body.companion_id();
             let ndofs = body.ndofs();
 

--- a/src/solver/nonlinear_sor_prox.rs
+++ b/src/solver/nonlinear_sor_prox.rs
@@ -37,7 +37,7 @@ impl NonlinearSORProx {
             }
 
             for constraint in internal_constraints {
-                if let Some(body) = bodies.body_mut(*constraint) {
+                if let Some(mut body) = bodies.body_mut(*constraint) {
                     body.step_solve_internal_position_constraints(params);
                 }
             }
@@ -88,13 +88,13 @@ impl NonlinearSORProx {
             // FIXME: the body update should be performed lazily, especially because
             // we dont actually need to update the kinematic of a multibody until
             // we have to solve a contact involving one of its links.
-            if let Some(b1) = bodies.body_mut(constraint.body1.0) {
+            if let Some(mut b1) = bodies.body_mut(constraint.body1.0) {
                 b1.apply_displacement(
                     &jacobians[constraint.wj_id1..constraint.wj_id1 + constraint.dim1],
                 );
             }
 
-            if let Some(b2) = bodies.body_mut(constraint.body2.0) {
+            if let Some(mut b2) = bodies.body_mut(constraint.body2.0) {
                 b2.apply_displacement(
                     &jacobians[constraint.wj_id2..constraint.wj_id2 + constraint.dim2],
                 )
@@ -119,12 +119,12 @@ impl NonlinearSORProx {
                 .mul_assign(impulse);
 
             if dim1.value() != 0 {
-                if let Some(b1) = bodies.body_mut(constraint.body1.0) {
+                if let Some(mut b1) = bodies.body_mut(constraint.body1.0) {
                     b1.apply_displacement(&jacobians[0..dim1.value()]);
                 }
             }
             if dim2.value() != 0 {
-                if let Some(b2) = bodies.body_mut(constraint.body2.0) {
+                if let Some(mut b2) = bodies.body_mut(constraint.body2.0) {
                     b2.apply_displacement(&jacobians[dim1.value()..dim1.value() + dim2.value()]);
                 }
             }

--- a/src/solver/signorini_coulomb_pyramid_model.rs
+++ b/src/solver/signorini_coulomb_pyramid_model.rs
@@ -65,8 +65,8 @@ impl<N: RealField> ContactModel<N> for SignoriniCoulombPyramidModel<N> {
         let id_friction = constraints.velocity.bilateral.len();
 
         for manifold in manifolds {
-            let body1 = try_continue!(bodies.body(manifold.body1()));
-            let body2 = try_continue!(bodies.body(manifold.body2()));
+            let body1 = &*try_continue!(bodies.body(manifold.body1()));
+            let body2 = &*try_continue!(bodies.body(manifold.body2()));
 
             for c in manifold.contacts() {
                 let part1 = try_continue!(body1.part(manifold.body_part1(c.kinematic.feature1()).1));

--- a/src/solver/signorini_model.rs
+++ b/src/solver/signorini_model.rs
@@ -202,8 +202,8 @@ impl<N: RealField> ContactModel<N> for SignoriniModel<N> {
         let id_vel = constraints.velocity.unilateral.len();
 
         for manifold in manifolds {
-            let body1 = try_ret!(bodies.body(manifold.body1()));
-            let body2 = try_ret!(bodies.body(manifold.body2()));
+            let body1 = &*try_ret!(bodies.body(manifold.body1()));
+            let body2 = &*try_ret!(bodies.body(manifold.body2()));
 
             for c in manifold.contacts() {
                  if !Self::is_constraint_active(c, manifold) {

--- a/src/solver/sor_prox.rs
+++ b/src/solver/sor_prox.rs
@@ -49,7 +49,7 @@ impl SORProx {
         }
 
         for handle in internal {
-            if let Some(body) = bodies.body_mut(*handle) {
+            if let Some(mut body) = bodies.body_mut(*handle) {
                 let mut dvels = mj_lambda.rows_mut(body.companion_id(), body.ndofs());
                 body.warmstart_internal_velocity_constraints(&mut dvels);
             }
@@ -140,7 +140,7 @@ impl SORProx {
         }
 
         for handle in internal {
-            if let Some(body) = bodies.body_mut(*handle) {
+            if let Some(mut body) = bodies.body_mut(*handle) {
                 let mut dvels = mj_lambda.rows_mut(body.companion_id(), body.ndofs());
                 body.step_solve_internal_velocity_constraints(&mut dvels);
             }


### PR DESCRIPTION
So this PR aim to add multithreading to nphysics.
This is still a draft, and a lot of things still need to be done.
I prefer to get some opinion before going further, in order to be sure we agree on the design choice.

### **So here is the actual choices made for this PR :** 

**1. In `Bodyset`, `body` and `ground` are now locked by a `RwLock` (from `parking_lot`) :** 

- When body or body_mut are called, It's returning a  `RwLockReadGuard` and `RwLockWriteGuard`.
This require `rigid_bidy()` and `multibody()` methods from `world` to be changed so I made them returning a `MappedReadLockGuard` (or `MappedWriteLockGuard` for the "mut" methods), in order to have `downcast()` working.

- when `add_body()` is called it was returning a `&mut` to a body trait object. With this PR, it should return the `RwLock`. I changed it and made it return the `BodyHandle` instead, because I thought it may be better than directly manipulate the `RwLock`. I am not really sure about this!

- One of the problem with `RwLock`, is that if you want to manipulate a body from your app, and let's say having a write lock, and then you call `step()`. If you forgot to unlock the body, it's going to block the app, and finally, you are going to have a lot of responsability when using nphysics!!
A solution would be to make the `RwLock` internal to the body, and each time you call a method, it's internally acquiring the appropriate lock ( read or write ) and then releasing it when finished. The problem is that it would probably kill performance.

- Another radically different alternative is to change `N: RealField` to `N: Atomic<RealField>` with the [atomic](https://github.com/Amanieu/atomic-rs) crate for example. Then It would be totally non-blocking, and the `RwLock` problem would not exist. We could use `Relaxed` ordering for maximum performance and rely on `fence` for memory barrier.
One possible issue would be for performance on weekly ordered architecture. I don't have experience on theses ones so I am not sure, but it seems that atomic operations are more expansive. How is it in reality? ( like on ARM for example)

**2. A step is divided in two methods. The master, and the slaves.**

- The master function ( named `step_multithread_master()` here ) distribute and manage work made by the "slaves" ( `step_multithread_slave()` ).

- Basically, the user clone a ref to the `World` struct between thread (with `Arc` for example), the main thread call the master function and the others call the slave one. In order to work with safe Rust, it need to entirely rely on interior mutability in order to safely share `World` between trade (With RwLock and/or Atomic like said upper).

- Master and slaves communicate through `MultithreadStep` struct, and each step has his own. The struct is still very basic and can be improved (with `Barrier` instead of constantly loading atomic values in a loop for example)

- nphysics itself doesn't manage threads.

**3. Example in Testbed3d**

- Testbed3d has been changed to support multithreading with the possibility to choose the number of threads with `set_thread_number()`. If it's 0, then the original `step()` method is called.

### Things That need to be done :

**1. Use exclusively interior mutability in `World` with RwLock/Atomic**

 - For the moment, only `Bodyset` has been rewritten. Because of that, unsafe is temporary used in testbed3d to make multithreading work.

**2. Complete master and slave method**

- Only `update_kinematics()` and `update_dynamics()` have been done.

**3. Reorganize `step` in smaller step ?**

- [comment](https://github.com/rustsim/nphysics/issues/149#issue-367433993)

**4. Rebase on top of CCD ?**

- Reading the blog of [rustsim](https://www.rustsim.org/blog/2019/04/01/this-month-in-rustsim/), you want to implement multithreading after ccd, so I can rebase it on top  of the [ccd branch](https://www.rustsim.org/blog/2019/04/01/this-month-in-rustsim/) if you want.

**5. Make ncollide multithreaded**

- One possibility is to make the master/slave system identical in _ncollide_. This way, we can call the slave and master methods of _ncollide_ in the respective methods of _nphysics_

**6. Other suggestions ?**

- If you have other design ideas ? Suggestions ? Remark ?