### PR TITLE
Deny bare trait-objects

### DIFF
--- a/examples3d/constraints3.rs
+++ b/examples3d/constraints3.rs
@@ -3,12 +3,12 @@ extern crate ncollide3d;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Isometry3, Point3, Vector3};
+use na::{Point3, Vector3};
 use ncollide3d::shape::{Cuboid, ShapeHandle};
 use nphysics3d::joint::{BallConstraint, PinSlotConstraint, PlanarConstraint, PrismaticConstraint,
                         RectangularConstraint, RevoluteConstraint, UniversalConstraint};
 use nphysics3d::object::{BodyPartHandle, ColliderDesc, RigidBodyDesc};
-use nphysics3d::volumetric::Volumetric;
+
 use nphysics3d::world::World;
 use nphysics_testbed3d::Testbed;
 use std::f32::consts::{FRAC_PI_2, PI};

--- a/examples3d/convex_decomposition3.rs
+++ b/examples3d/convex_decomposition3.rs
@@ -6,12 +6,12 @@ extern crate nphysics_testbed3d;
 extern crate rand;
 
 use std::path::Path;
-use na::{Isometry3, Point3, Translation3, Vector3};
+use na::{Point3, Translation3, Vector3};
 use kiss3d::loader::obj;
 use ncollide3d::shape::{Compound, ConvexHull, Cuboid, ShapeHandle};
 use ncollide3d::procedural::TriMesh;
 use ncollide3d::transformation;
-use ncollide3d::bounding_volume::{self, BoundingVolume, AABB};
+use ncollide3d::bounding_volume::{self, BoundingVolume};
 use nphysics3d::world::World;
 use nphysics3d::object::{ColliderDesc, RigidBodyDesc};
 use nphysics_testbed3d::Testbed;

--- a/examples3d/fem_volume3.rs
+++ b/examples3d/fem_volume3.rs
@@ -3,7 +3,7 @@ extern crate ncollide3d;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Point3, Vector3, Point4};
+use na::{Point3, Vector3};
 use ncollide3d::shape::{Cuboid, ShapeHandle};
 use nphysics3d::object::{FEMVolumeDesc, ColliderDesc};
 use nphysics3d::world::World;

--- a/examples3d/known_bug_excentric_convex3.rs
+++ b/examples3d/known_bug_excentric_convex3.rs
@@ -24,12 +24,12 @@ extern crate ncollide3d;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Isometry3, Point3, Vector3};
+use na::{Point3, Vector3};
 use ncollide3d::shape::{ConvexHull, Cuboid, ShapeHandle};
-use ncollide3d::procedural;
+
 use nphysics3d::world::World;
 use nphysics3d::object::{ColliderDesc, RigidBodyDesc};
-use nphysics3d::volumetric::Volumetric;
+
 use nphysics_testbed3d::Testbed;
 
 

--- a/nphysics_testbed2d/src/engine.rs
+++ b/nphysics_testbed2d/src/engine.rs
@@ -213,7 +213,7 @@ impl GraphicsManager {
         object: ColliderHandle,
         world: &World<f32>,
         delta: Isometry2<f32>,
-        shape: &Shape<f32>,
+        shape: &dyn Shape<f32>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
@@ -429,8 +429,8 @@ impl GraphicsManager {
     //     }
     // }
 
-    pub fn camera_mut<'a>(&'a mut self) -> &'a mut PlanarCamera {
-        &mut self.camera as &'a mut PlanarCamera
+    pub fn camera_mut<'a>(&'a mut self) -> &'a mut dyn PlanarCamera {
+        &mut self.camera as &'a mut dyn PlanarCamera
     }
 
     pub fn look_at(&mut self, at: Point2<f32>, zoom: f32) {

--- a/nphysics_testbed2d/src/testbed.rs
+++ b/nphysics_testbed2d/src/testbed.rs
@@ -91,11 +91,11 @@ pub struct Testbed {
     cursor_pos: Point2<f32>,
     grabbed_object: Option<BodyPartHandle>,
     grabbed_object_constraint: Option<ConstraintHandle>,
-    world: Box<WorldOwner>,
+    world: Box<dyn WorldOwner>,
     drawing_ray: Option<Point2<f32>>,
 }
 
-type Callbacks = Vec<Box<Fn(&mut WorldOwner, &mut GraphicsManager, f32)>>;
+type Callbacks = Vec<Box<dyn Fn(&mut dyn WorldOwner, &mut GraphicsManager, f32)>>;
 
 impl Testbed {
     pub fn new_empty() -> Testbed {
@@ -130,7 +130,7 @@ impl Testbed {
         Testbed::new_with_world_owner(Box::new(world))
     }
 
-    pub fn new_with_world_owner(world_owner: Box<WorldOwner>) -> Testbed {
+    pub fn new_with_world_owner(world_owner: Box<dyn WorldOwner>) -> Testbed {
         let mut res = Testbed::new_empty();
 
         res.set_world_owner(world_owner);
@@ -154,7 +154,7 @@ impl Testbed {
         self.set_world_owner(Box::new(world));
     }
 
-    pub fn set_world_owner(&mut self, world: Box<WorldOwner>) {
+    pub fn set_world_owner(&mut self, world: Box<dyn WorldOwner>) {
         self.world = world;
         let mut world = self.world.get_mut();
         world.enable_performance_counters();
@@ -179,7 +179,7 @@ impl Testbed {
         self.graphics.set_collider_color(collider, color);
     }
 
-    pub fn world(&self) -> &Box<WorldOwner> {
+    pub fn world(&self) -> &Box<dyn WorldOwner> {
         &self.world
     }
 
@@ -214,7 +214,7 @@ impl Testbed {
         res
     }
 
-    pub fn add_callback<F: Fn(&mut WorldOwner, &mut GraphicsManager, f32) + 'static>(
+    pub fn add_callback<F: Fn(&mut dyn WorldOwner, &mut GraphicsManager, f32) + 'static>(
         &mut self,
         callback: F,
     ) {
@@ -242,9 +242,9 @@ impl Testbed {
 }
 
 type CameraEffects<'a> = (
-    Option<&'a mut Camera>,
-    Option<&'a mut PlanarCamera>,
-    Option<&'a mut PostProcessingEffect>,
+    Option<&'a mut dyn Camera>,
+    Option<&'a mut dyn PlanarCamera>,
+    Option<&'a mut dyn PostProcessingEffect>,
 );
 
 impl State for Testbed {

--- a/nphysics_testbed2d/src/world_owner.rs
+++ b/nphysics_testbed2d/src/world_owner.rs
@@ -9,26 +9,26 @@ use std::sync::RwLock;
 pub trait WorldOwner {
     // FIXME: avoid the systematic Box by using associated type
     // which also requires the testbed to be parametrized by the world type.
-    fn get<'a: 'b, 'b>(&'a self) -> Box<Deref<Target=World<f32>> + 'b>;
-    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<DerefMut<Target=World<f32>> + 'b>;
+    fn get<'a: 'b, 'b>(&'a self) -> Box<dyn Deref<Target=World<f32>> + 'b>;
+    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<dyn DerefMut<Target=World<f32>> + 'b>;
 }
 
 impl WorldOwner for World<f32> {
-    fn get<'a: 'b, 'b>(&'a self) -> Box<Deref<Target=World<f32>> + 'b> {
+    fn get<'a: 'b, 'b>(&'a self) -> Box<dyn Deref<Target=World<f32>> + 'b> {
         Box::new(self)
     }
 
-    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<DerefMut<Target=World<f32>> + 'b> {
+    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<dyn DerefMut<Target=World<f32>> + 'b> {
         Box::new(self)
     }
 }
 
 impl WorldOwner for Arc<RwLock<World<f32>>> {
-    fn get<'a: 'b, 'b>(&'a self) -> Box<Deref<Target=World<f32>> + 'b> {
+    fn get<'a: 'b, 'b>(&'a self) -> Box<dyn Deref<Target=World<f32>> + 'b> {
         Box::new(self.read().unwrap())
     }
 
-    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<DerefMut<Target=World<f32>> + 'b> {
+    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<dyn DerefMut<Target=World<f32>> + 'b> {
         Box::new(self.write().unwrap())
     }
 }

--- a/nphysics_testbed3d/src/engine.rs
+++ b/nphysics_testbed3d/src/engine.rs
@@ -213,7 +213,7 @@ impl GraphicsManager {
         object: ColliderHandle,
         world: &World<f32>,
         delta: Isometry3<f32>,
-        shape: &Shape<f32>,
+        shape: &dyn Shape<f32>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
@@ -443,19 +443,19 @@ impl GraphicsManager {
         self.curr_is_arc_ball = !self.curr_is_arc_ball;
     }
 
-    pub fn camera<'a>(&'a self) -> &'a Camera {
+    pub fn camera<'a>(&'a self) -> &'a dyn Camera {
         if self.curr_is_arc_ball {
-            &self.arc_ball as &'a Camera
+            &self.arc_ball as &'a dyn Camera
         } else {
-            &self.first_person as &'a Camera
+            &self.first_person as &'a dyn Camera
         }
     }
 
-    pub fn camera_mut<'a>(&'a mut self) -> &'a mut Camera {
+    pub fn camera_mut<'a>(&'a mut self) -> &'a mut dyn Camera {
         if self.curr_is_arc_ball {
-            &mut self.arc_ball as &'a mut Camera
+            &mut self.arc_ball as &'a mut dyn Camera
         } else {
-            &mut self.first_person as &'a mut Camera
+            &mut self.first_person as &'a mut dyn Camera
         }
     }
 

--- a/nphysics_testbed3d/src/testbed.rs
+++ b/nphysics_testbed3d/src/testbed.rs
@@ -81,7 +81,7 @@ fn usage(exe_name: &str) {
 }
 
 pub struct Testbed {
-    world: Box<WorldOwner>,
+    world: Box<dyn WorldOwner>,
     window: Option<Box<Window>>,
     graphics: GraphicsManager,
     nsteps: usize,
@@ -99,7 +99,7 @@ pub struct Testbed {
     grabbed_object_plane: (Point3<f32>, Vector3<f32>),
 }
 
-type Callbacks = Vec<Box<Fn(&mut WorldOwner, &mut GraphicsManager, f32)>>;
+type Callbacks = Vec<Box<dyn Fn(&mut dyn WorldOwner, &mut GraphicsManager, f32)>>;
 
 impl Testbed {
     pub fn new_empty() -> Testbed {
@@ -134,7 +134,7 @@ impl Testbed {
         Self::new_with_world_owner(Box::new(world))
     }
 
-    pub fn new_with_world_owner(world: Box<WorldOwner>) -> Self {
+    pub fn new_with_world_owner(world: Box<dyn WorldOwner>) -> Self {
         let mut res = Testbed::new_empty();
 
         res.set_world_owner(world);
@@ -157,7 +157,7 @@ impl Testbed {
         self.set_world_owner(Box::new(world))
     }
 
-    pub fn set_world_owner(&mut self, world: Box<WorldOwner>) {
+    pub fn set_world_owner(&mut self, world: Box<dyn WorldOwner>) {
         self.world = world;
         let mut world = self.world.get_mut();
         world.enable_performance_counters();
@@ -182,7 +182,7 @@ impl Testbed {
         self.graphics.set_collider_color(collider, color);
     }
 
-    pub fn world(&self) -> &Box<WorldOwner> {
+    pub fn world(&self) -> &Box<dyn WorldOwner> {
         &self.world
     }
 
@@ -217,7 +217,7 @@ impl Testbed {
         res
     }
 
-    pub fn add_callback<F: Fn(&mut WorldOwner, &mut GraphicsManager, f32) + 'static>(
+    pub fn add_callback<F: Fn(&mut dyn WorldOwner, &mut GraphicsManager, f32) + 'static>(
         &mut self,
         callback: F,
     ) {
@@ -245,9 +245,9 @@ impl Testbed {
 }
 
 type CameraEffects<'a> = (
-    Option<&'a mut Camera>,
-    Option<&'a mut PlanarCamera>,
-    Option<&'a mut PostProcessingEffect>,
+    Option<&'a mut dyn Camera>,
+    Option<&'a mut dyn PlanarCamera>,
+    Option<&'a mut dyn PostProcessingEffect>,
 );
 
 impl State for Testbed {

--- a/nphysics_testbed3d/src/world_owner.rs
+++ b/nphysics_testbed3d/src/world_owner.rs
@@ -9,26 +9,26 @@ use std::sync::RwLock;
 pub trait WorldOwner {
     // FIXME: avoid the systematic Box by using associated type
     // which also requires the testbed to be parametrized by the world type.
-    fn get<'a: 'b, 'b>(&'a self) -> Box<Deref<Target=World<f32>> + 'b>;
-    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<DerefMut<Target=World<f32>> + 'b>;
+    fn get<'a: 'b, 'b>(&'a self) -> Box<dyn Deref<Target=World<f32>> + 'b>;
+    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<dyn DerefMut<Target=World<f32>> + 'b>;
 }
 
 impl WorldOwner for World<f32> {
-    fn get<'a: 'b, 'b>(&'a self) -> Box<Deref<Target=World<f32>> + 'b> {
+    fn get<'a: 'b, 'b>(&'a self) -> Box<dyn Deref<Target=World<f32>> + 'b> {
         Box::new(self)
     }
 
-    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<DerefMut<Target=World<f32>> + 'b> {
+    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<dyn DerefMut<Target=World<f32>> + 'b> {
         Box::new(self)
     }
 }
 
 impl WorldOwner for Arc<RwLock<World<f32>>> {
-    fn get<'a: 'b, 'b>(&'a self) -> Box<Deref<Target=World<f32>> + 'b> {
+    fn get<'a: 'b, 'b>(&'a self) -> Box<dyn Deref<Target=World<f32>> + 'b> {
         Box::new(self.read().unwrap())
     }
 
-    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<DerefMut<Target=World<f32>> + 'b> {
+    fn get_mut<'a: 'b, 'b>(&'a mut self) -> Box<dyn DerefMut<Target=World<f32>> + 'b> {
         Box::new(self.write().unwrap())
     }
 }

--- a/src/detection/activation_manager.rs
+++ b/src/detection/activation_manager.rs
@@ -45,7 +45,7 @@ impl<N: RealField> ActivationManager<N> {
         self.to_activate.push(handle);
     }
 
-    fn update_energy(&self, body: &mut Body<N>) {
+    fn update_energy(&self, body: &mut dyn Body<N>) {
         // FIXME: avoid the Copy when NLL lands ?
         let status = *body.activation_status();
 
@@ -63,7 +63,7 @@ impl<N: RealField> ActivationManager<N> {
         &mut self,
         bodies: &mut BodySet<N>,
         cworld: &ColliderWorld<N>,
-        constraints: &Slab<Box<JointConstraint<N>>>,
+        constraints: &Slab<Box<dyn JointConstraint<N>>>,
         active_bodies: &mut Vec<BodyHandle>,
     ) {
         /*

--- a/src/joint/ball_joint.rs
+++ b/src/joint/ball_joint.rs
@@ -30,7 +30,7 @@ impl<N: RealField> BallJoint<N> {
 
 impl<N: RealField> Joint<N> for BallJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/joint/cartesian_joint.rs
+++ b/src/joint/cartesian_joint.rs
@@ -19,7 +19,7 @@ impl<N: RealField> CartesianJoint<N> {
 
 impl<N: RealField> Joint<N> for CartesianJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/joint/cylindrical_joint.rs
+++ b/src/joint/cylindrical_joint.rs
@@ -26,7 +26,7 @@ impl<N: RealField> CylindricalJoint<N> {
 
 impl<N: RealField> Joint<N> for CylindricalJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/joint/fixed_joint.rs
+++ b/src/joint/fixed_joint.rs
@@ -24,7 +24,7 @@ impl<N: RealField> FixedJoint<N> {
 
 impl<N: RealField> Joint<N> for FixedJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/joint/free_joint.rs
+++ b/src/joint/free_joint.rs
@@ -29,7 +29,7 @@ impl<N: RealField> FreeJoint<N> {
 
 impl<N: RealField> Joint<N> for FreeJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/joint/helical_joint.rs
+++ b/src/joint/helical_joint.rs
@@ -40,7 +40,7 @@ impl<N: RealField> HelicalJoint<N> {
 
 impl<N: RealField> Joint<N> for HelicalJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/joint/joint.rs
+++ b/src/joint/joint.rs
@@ -85,7 +85,7 @@ pub trait Joint<N: RealField>: Downcast + Send + Sync {
         None
     }
 
-    fn clone(&self) -> Box<Joint<N>>;
+    fn clone(&self) -> Box<dyn Joint<N>>;
 }
 
 impl_downcast!(Joint<N> where N: RealField);

--- a/src/joint/pin_slot_joint.rs
+++ b/src/joint/pin_slot_joint.rs
@@ -37,7 +37,7 @@ impl<N: RealField> PinSlotJoint<N> {
 
 impl<N: RealField> Joint<N> for PinSlotJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/joint/planar_joint.rs
+++ b/src/joint/planar_joint.rs
@@ -44,7 +44,7 @@ impl<N: RealField> PlanarJoint<N> {
 
 impl<N: RealField> Joint<N> for PlanarJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/joint/prismatic_joint.rs
+++ b/src/joint/prismatic_joint.rs
@@ -139,7 +139,7 @@ impl<N: RealField> PrismaticJoint<N> {
 
 impl<N: RealField> Joint<N> for PrismaticJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/joint/rectangular_joint.rs
+++ b/src/joint/rectangular_joint.rs
@@ -26,7 +26,7 @@ impl<N: RealField> RectangularJoint<N> {
 
 impl<N: RealField> Joint<N> for RectangularJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/joint/revolute_joint.rs
+++ b/src/joint/revolute_joint.rs
@@ -178,7 +178,7 @@ impl<N: RealField> RevoluteJoint<N> {
 
 impl<N: RealField> Joint<N> for RevoluteJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/joint/unit_constraint.rs
+++ b/src/joint/unit_constraint.rs
@@ -6,10 +6,10 @@ use crate::solver::{helper, BilateralConstraint, BilateralGroundConstraint, Cons
              ForceDirection, GenericNonlinearConstraint, ImpulseLimits, IntegrationParameters};
 
 pub fn build_linear_limits_velocity_constraint<N: RealField>(
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     assembly_id1: usize,
     assembly_id2: usize,
     anchor1: &Point<N>,
@@ -123,10 +123,10 @@ pub fn build_linear_limits_velocity_constraint<N: RealField>(
 
 pub fn build_linear_limits_position_constraint<N: RealField>(
     params: &IntegrationParameters<N>,
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     anchor1: &Point<N>,
     anchor2: &Point<N>,
     axis: &Unit<Vector<N>>,

--- a/src/joint/universal_joint.rs
+++ b/src/joint/universal_joint.rs
@@ -31,7 +31,7 @@ impl<N: RealField> UniversalJoint<N> {
 
 impl<N: RealField> Joint<N> for UniversalJoint<N> {
     #[inline]
-    fn clone(&self) -> Box<Joint<N>> {
+    fn clone(&self) -> Box<dyn Joint<N>> {
         Box::new(*self)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@ The libraries needed to compile the physics engine are:
 The libraries needed to compile the examples are:
 
 */
+
+#![deny(bare_trait_objects)]
 #![deny(non_camel_case_types)]
 #![deny(unused_parens)]
 #![deny(non_upper_case_globals)]
@@ -214,25 +216,25 @@ macro_rules! user_data_accessors(
     () => {
         /// Retrieves a reference to the user-defined user-data attached to this object.
         #[inline]
-        pub fn user_data(&self) -> Option<&(Any + Send + Sync)> {
+        pub fn user_data(&self) -> Option<&(dyn Any + Send + Sync)> {
             self.user_data.as_ref().map(|d| &**d)
         }
 
         /// Retrieves a mutable reference to the user-defined user-data attached to this object.
         #[inline]
-        pub fn user_data_mut(&mut self) -> Option<&mut (Any + Send + Sync)> {
+        pub fn user_data_mut(&mut self) -> Option<&mut (dyn Any + Send + Sync)> {
             self.user_data.as_mut().map(|d| &mut **d)
         }
 
         /// Sets the user-defined data attached to this object.
         #[inline]
-        pub fn set_user_data(&mut self, data: Option<Box<Any + Send + Sync>>) -> Option<Box<Any + Send + Sync>> {
+        pub fn set_user_data(&mut self, data: Option<Box<dyn Any + Send + Sync>>) -> Option<Box<dyn Any + Send + Sync>> {
             std::mem::replace(&mut self.user_data, data)
         }
 
         /// Replace by `None` the user-defined data attached to this object and returns the old value.
         #[inline]
-        pub fn take_user_data(&mut self) -> Option<Box<Any + Send + Sync>> {
+        pub fn take_user_data(&mut self) -> Option<Box<dyn Any + Send + Sync>> {
             self.user_data.take()
         }
     }
@@ -243,18 +245,18 @@ macro_rules! user_data_desc_accessors(
     () => {
         /// Sets a user-data to be attached to the object being built.
         pub fn user_data(mut self, data: impl UserData) -> Self {
-            self.user_data = Some(UserDataBox(Box::new(data) as Box<UserData>));
+            self.user_data = Some(UserDataBox(Box::new(data) as Box<dyn UserData>));
             self
         }
 
         /// Sets the user-data to be attached to the object being built.
         pub fn set_user_data(&mut self, data: Option<impl UserData>) -> &mut Self {
-            self.user_data = data.map(|data| UserDataBox(Box::new(data) as Box<UserData>));
+            self.user_data = data.map(|data| UserDataBox(Box::new(data) as Box<dyn UserData>));
             self
         }
 
         /// Reference to the user-data to be attached to the object being built.
-        pub fn get_user_data(&self) -> Option<&(Any + Send + Sync)> {
+        pub fn get_user_data(&self) -> Option<&(dyn Any + Send + Sync)> {
             self.user_data.as_ref().map(|data| data.0.as_any())
         }
     }

--- a/src/material/material.rs
+++ b/src/material/material.rs
@@ -13,9 +13,9 @@ use crate::math::Vector;
 #[derive(Copy, Clone)]
 pub struct MaterialContext<'a, N: RealField> {
     /// One of the two bodies involved in the contact.
-    pub body: &'a Body<N>,
+    pub body: &'a dyn Body<N>,
     /// One of the two bodies part involved in the contact.
-    pub body_part: &'a BodyPart<N>,
+    pub body_part: &'a dyn BodyPart<N>,
     /// One of the two colliders involved in the contact.
     pub collider: &'a Collider<N>,
     /// The contact.
@@ -28,7 +28,7 @@ pub struct MaterialContext<'a, N: RealField> {
 }
 
 impl<'a, N: RealField> MaterialContext<'a, N> {
-    pub(crate) fn new(body: &'a Body<N>, body_part: &'a BodyPart<N>, collider: &'a Collider<N>, contact: &'a TrackedContact<N>, is_first: bool) -> Self {
+    pub(crate) fn new(body: &'a dyn Body<N>, body_part: &'a dyn BodyPart<N>, collider: &'a Collider<N>, contact: &'a TrackedContact<N>, is_first: bool) -> Self {
         MaterialContext {
             body,
             body_part,
@@ -93,7 +93,7 @@ pub struct LocalMaterialProperties<N: RealField> {
 /// An utility trait to clone material trait-objects.
 pub trait MaterialClone<N: RealField> {
     /// Clone a material trait-object.
-    fn clone_box(&self) -> Box<Material<N>> {
+    fn clone_box(&self) -> Box<dyn Material<N>> {
         unimplemented!()
     }
 }
@@ -102,7 +102,7 @@ pub trait MaterialClone<N: RealField> {
 pub type MaterialId = u32;
 
 impl<N: RealField, T: 'static + Material<N> + Clone> MaterialClone<N> for T {
-    fn clone_box(&self) -> Box<Material<N>> {
+    fn clone_box(&self) -> Box<dyn Material<N>> {
         Box::new(self.clone())
     }
 }
@@ -115,13 +115,13 @@ pub trait Material<N: RealField>: Downcast + Send + Sync + MaterialClone<N> {
 
 impl_downcast!(Material<N> where N: RealField);
 
-impl<N: RealField> Clone for Box<Material<N>> {
-    fn clone(&self) -> Box<Material<N>> {
+impl<N: RealField> Clone for Box<dyn Material<N>> {
+    fn clone(&self) -> Box<dyn Material<N>> {
         self.clone_box()
     }
 }
 
-impl<N: RealField> Material<N> {
+impl<N: RealField> dyn Material<N> {
     /// Combine two materials given their contexts and a material lookup table.
     pub fn combine<M1, M2>(
         table: &MaterialsCoefficientsTable<N>,
@@ -169,7 +169,7 @@ impl<N: RealField> Material<N> {
 ///
 /// This can be mutated using COW.
 #[derive(Clone)]
-pub struct MaterialHandle<N: RealField>(Arc<Box<Material<N>>>);
+pub struct MaterialHandle<N: RealField>(Arc<Box<dyn Material<N>>>);
 
 impl<N: RealField> MaterialHandle<N> {
     /// Creates a sharable shape handle from a shape.
@@ -178,23 +178,23 @@ impl<N: RealField> MaterialHandle<N> {
         MaterialHandle(Arc::new(Box::new(material)))
     }
 
-    pub(crate) fn make_mut(&mut self) -> &mut Material<N> {
+    pub(crate) fn make_mut(&mut self) -> &mut dyn Material<N> {
         &mut **Arc::make_mut(&mut self.0)
     }
 }
 
-impl<N: RealField> AsRef<Material<N>> for MaterialHandle<N> {
+impl<N: RealField> AsRef<dyn Material<N>> for MaterialHandle<N> {
     #[inline]
-    fn as_ref(&self) -> &Material<N> {
+    fn as_ref(&self) -> &dyn Material<N> {
         &*self.deref()
     }
 }
 
 impl<N: RealField> Deref for MaterialHandle<N> {
-    type Target = Material<N>;
+    type Target = dyn Material<N>;
 
     #[inline]
-    fn deref(&self) -> &Material<N> {
+    fn deref(&self) -> &dyn Material<N> {
         &**self.0.deref()
     }
 }

--- a/src/object/body.rs
+++ b/src/object/body.rs
@@ -174,7 +174,7 @@ pub trait Body<N: RealField>: Downcast + Send + Sync {
     fn deactivate(&mut self);
 
     /// A reference to the specified body part.
-    fn part(&self, i: usize) -> Option<&BodyPart<N>>;
+    fn part(&self, i: usize) -> Option<&dyn BodyPart<N>>;
 
     /// If this is a deformable body, returns its deformed positions.
     fn deformed_positions(&self) -> Option<(DeformationsType, &[N])>;
@@ -189,7 +189,7 @@ pub trait Body<N: RealField>: Downcast + Send + Sync {
     /// If the force is a torque, it is applied at the center of mass of the body part.
     fn fill_constraint_geometry(
         &self,
-        part: &BodyPart<N>,
+        part: &dyn BodyPart<N>,
         ndofs: usize, // FIXME: keep this parameter?
         center: &Point<N>,
         dir: &ForceDirection<N>,
@@ -202,13 +202,13 @@ pub trait Body<N: RealField>: Downcast + Send + Sync {
     );
 
     /// Transform the given point expressed in material coordinates to world-space.
-    fn world_point_at_material_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Point<N>;
+    fn world_point_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Point<N>;
 
     /// Transform the given point expressed in material coordinates to world-space.
-    fn position_at_material_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Isometry<N>;
+    fn position_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Isometry<N>;
 
     /// Transform the given point expressed in material coordinates to world-space.
-    fn material_point_at_world_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Point<N>;
+    fn material_point_at_world_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Point<N>;
 
     /// Returns `true` if this bodies contains internal constraints that need to be solved.
     fn has_active_internal_constraints(&mut self) -> bool;
@@ -246,7 +246,7 @@ pub trait Body<N: RealField>: Downcast + Send + Sync {
     ///
     /// This will return a zero velocity for any body with a status different than `BodyStatus::Dynamic`.
     #[inline]
-    fn status_dependent_body_part_velocity(&self, part: &BodyPart<N>) -> Velocity<N> {
+    fn status_dependent_body_part_velocity(&self, part: &dyn BodyPart<N>) -> Velocity<N> {
         if self.is_dynamic() {
             part.velocity()
         } else {

--- a/src/object/body_set.rs
+++ b/src/object/body_set.rs
@@ -115,7 +115,7 @@ pub trait BodyDesc<N: RealField> {
 /// A set containing all the bodies added to the world.
 pub struct BodySet<N: RealField> {
     ground: Ground<N>,
-    bodies: Slab<Box<Body<N>>>,
+    bodies: Slab<Box<dyn Body<N>>>,
 }
 
 impl<N: RealField> BodySet<N> {
@@ -160,7 +160,7 @@ impl<N: RealField> BodySet<N> {
     ///
     /// Returns `None` if the body is not found.
     #[inline]
-    pub fn body(&self, handle: BodyHandle) -> Option<&Body<N>> {
+    pub fn body(&self, handle: BodyHandle) -> Option<&dyn Body<N>> {
         if handle.is_ground() {
             Some(&self.ground)
         } else {
@@ -172,7 +172,7 @@ impl<N: RealField> BodySet<N> {
     ///
     /// Returns `None` if the body is not found.
     #[inline]
-    pub fn body_mut(&mut self, handle: BodyHandle) -> Option<&mut Body<N>> {
+    pub fn body_mut(&mut self, handle: BodyHandle) -> Option<&mut dyn Body<N>> {
         if handle.is_ground() {
             Some(&mut self.ground)
         } else {
@@ -182,18 +182,18 @@ impl<N: RealField> BodySet<N> {
 
     /// Iterator yielding all the bodies on this set.
     #[inline]
-    pub fn bodies(&self) -> impl Iterator<Item = &Body<N>> {
+    pub fn bodies(&self) -> impl Iterator<Item = &dyn Body<N>> {
         self.bodies.iter().map(|e| &**e.1)
     }
 
     /// Mutable iterator yielding all the bodies on this set.
     #[inline]
-    pub fn bodies_mut(&mut self) -> impl Iterator<Item = &mut Body<N>> {
+    pub fn bodies_mut(&mut self) -> impl Iterator<Item = &mut dyn Body<N>> {
         self.bodies.iter_mut().map(|e| &mut **e.1)
     }
 }
 
 /// Iterator yielding all the bodies on a body set.
-pub type Bodies<'a, N> = Iter<'a, Box<Body<N>>>;
+pub type Bodies<'a, N> = Iter<'a, Box<dyn Body<N>>>;
 /// Mutable iterator yielding all the bodies on a body set.
-pub type BodiesMut<'a, N> = IterMut<'a, Box<Body<N>>>;
+pub type BodiesMut<'a, N> = IterMut<'a, Box<dyn Body<N>>>;

--- a/src/object/collider.rs
+++ b/src/object/collider.rs
@@ -62,7 +62,7 @@ pub struct ColliderData<N: RealField> {
     // NOTE: needed for the collision filter.
     body_status_dependent_ndofs: usize,
     material: MaterialHandle<N>,
-    user_data: Option<Box<Any + Send + Sync>>,
+    user_data: Option<Box<dyn Any + Send + Sync>>,
 }
 
 impl<N: RealField> ColliderData<N> {
@@ -129,7 +129,7 @@ impl<N: RealField> ColliderData<N> {
 
     /// The material of this collider.
     #[inline]
-    pub fn material(&self) -> &Material<N> {
+    pub fn material(&self) -> &dyn Material<N> {
         &*self.material
     }
 
@@ -139,7 +139,7 @@ impl<N: RealField> ColliderData<N> {
     /// before returning the mutable reference (this effectively call
     /// the `Arc::make_mut` method to get a copy-on-write behavior).
     #[inline]
-    pub fn material_mut(&mut self) -> &mut Material<N> {
+    pub fn material_mut(&mut self) -> &mut dyn Material<N> {
         self.material.make_mut()
     }
 
@@ -177,25 +177,25 @@ impl<N: RealField> Collider<N> {
      */
     /// The user-data attached to this collider.
     #[inline]
-    pub fn user_data(&self) -> Option<&(Any + Send + Sync)> {
+    pub fn user_data(&self) -> Option<&(dyn Any + Send + Sync)> {
         self.0.data().user_data.as_ref().map(|d| &**d)
     }
 
     /// Mutable reference to the user-data attached to this collider.
     #[inline]
-    pub fn user_data_mut(&mut self) -> Option<&mut (Any + Send + Sync)> {
+    pub fn user_data_mut(&mut self) -> Option<&mut (dyn Any + Send + Sync)> {
         self.0.data_mut().user_data.as_mut().map(|d| &mut **d)
     }
 
     /// Sets the user-data attached to this collider.
     #[inline]
-    pub fn set_user_data(&mut self, data: Option<Box<Any + Send + Sync>>) -> Option<Box<Any + Send + Sync>> {
+    pub fn set_user_data(&mut self, data: Option<Box<dyn Any + Send + Sync>>) -> Option<Box<dyn Any + Send + Sync>> {
         std::mem::replace(&mut self.0.data_mut().user_data, data)
     }
 
     /// Replace the user-data of this collider by `None` and returns the old value.
     #[inline]
-    pub fn take_user_data(&mut self) -> Option<Box<Any + Send + Sync>> {
+    pub fn take_user_data(&mut self) -> Option<Box<dyn Any + Send + Sync>> {
         self.0.data_mut().user_data.take()
     }
 
@@ -227,7 +227,7 @@ impl<N: RealField> Collider<N> {
 
     /// The material of this collider.
     #[inline]
-    pub fn material(&self) -> &Material<N> {
+    pub fn material(&self) -> &dyn Material<N> {
         self.0.data().material()
     }
 
@@ -406,10 +406,10 @@ impl<N: RealField> ColliderDesc<N> {
     );
 
     desc_custom_getters!(
-        self.get_shape: &Shape<N> | { &*self.shape }
+        self.get_shape: &dyn Shape<N> | { &*self.shape }
         self.get_name: &str | { &self.name }
         self.get_translation: &Vector<N> | { &self.position.translation.vector }
-        self.get_material: Option<&Material<N>> | { self.material.as_ref().map(|m| &**m) }
+        self.get_material: Option<&dyn Material<N>> | { self.material.as_ref().map(|m| &**m) }
     );
 
     desc_getters!(
@@ -441,7 +441,7 @@ impl<N: RealField> ColliderDesc<N> {
     // Returns `None` if the given body part does not exist.
     pub(crate) fn build_with_infos<'w>(&self,
                                        parent: BodyPartHandle,
-                                       body: &mut Body<N>,
+                                       body: &mut dyn Body<N>,
                                        cworld: &'w mut ColliderWorld<N>)
                                     -> Option<&'w mut Collider<N>> {
         let query = if self.is_sensor {
@@ -551,9 +551,9 @@ impl<N: RealField> DeformableColliderDesc<N> {
     );
 
     desc_custom_getters!(
-        self.get_shape: &Shape<N> | { &*self.shape }
+        self.get_shape: &dyn Shape<N> | { &*self.shape }
         self.get_name: &str | { &self.name }
-        self.get_material: Option<&Material<N>> | { self.material.as_ref().map(|m| &**m) }
+        self.get_material: Option<&dyn Material<N>> | { self.material.as_ref().map(|m| &**m) }
 
     );
 
@@ -573,7 +573,7 @@ impl<N: RealField> DeformableColliderDesc<N> {
     }
 
     pub(crate) fn build_with_infos<'w>(&self,
-                                       parent: &Body<N>,
+                                       parent: &dyn Body<N>,
                                        cworld: &'w mut ColliderWorld<N>)
                                        -> &'w mut Collider<N> {
         let query = if self.is_sensor {

--- a/src/object/fem_surface.rs
+++ b/src/object/fem_surface.rs
@@ -74,7 +74,7 @@ pub struct FEMSurface<N: RealField> {
     update_status: BodyUpdateStatus,
 
 
-    user_data: Option<Box<Any + Send + Sync>>,
+    user_data: Option<Box<dyn Any + Send + Sync>>,
 }
 
 impl<N: RealField> FEMSurface<N> {
@@ -777,29 +777,29 @@ impl<N: RealField> Body<N> for FEMSurface<N> {
         self.activation.set_deactivation_threshold(threshold)
     }
 
-    fn part(&self, id: usize) -> Option<&BodyPart<N>> {
-        self.elements.get(id).map(|b| b as &BodyPart<N>)
+    fn part(&self, id: usize) -> Option<&dyn BodyPart<N>> {
+        self.elements.get(id).map(|b| b as &dyn BodyPart<N>)
     }
 
-    fn world_point_at_material_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn world_point_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         let elt = part.downcast_ref::<TriangularElement<N>>().expect("The provided body part must be a triangular element");
         fem_helper::world_point_at_material_point(FiniteElementIndices::Triangle(elt.indices), &self.positions, point)
     }
 
-    fn position_at_material_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Isometry<N> {
+    fn position_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Isometry<N> {
         let elt = part.downcast_ref::<TriangularElement<N>>().expect("The provided body part must be a triangular element");
         let pt = fem_helper::world_point_at_material_point(FiniteElementIndices::Triangle(elt.indices), &self.positions, point);
         Isometry::from_parts(Translation::from(pt.coords), na::one())
     }
 
-    fn material_point_at_world_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn material_point_at_world_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         let elt = part.downcast_ref::<TriangularElement<N>>().expect("The provided body part must be a triangular element");
         fem_helper::material_point_at_world_point(FiniteElementIndices::Triangle(elt.indices), &self.positions, point)
     }
 
     fn fill_constraint_geometry(
         &self,
-        part: &BodyPart<N>,
+        part: &dyn BodyPart<N>,
         _: usize, // FIXME: keep this parameter?
         center: &Point<N>,
         force_dir: &ForceDirection<N>,

--- a/src/object/fem_volume.rs
+++ b/src/object/fem_volume.rs
@@ -74,7 +74,7 @@ pub struct FEMVolume<N: RealField> {
     status: BodyStatus,
     update_status: BodyUpdateStatus,
 
-    user_data: Option<Box<Any + Send + Sync>>,
+    user_data: Option<Box<dyn Any + Send + Sync>>,
 }
 
 impl<N: RealField> FEMVolume<N> {
@@ -834,29 +834,29 @@ impl<N: RealField> Body<N> for FEMVolume<N> {
         self.activation.set_deactivation_threshold(threshold)
     }
 
-    fn part(&self, id: usize) -> Option<&BodyPart<N>> {
-        self.elements.get(id).map(|e| e as &BodyPart<N>)
+    fn part(&self, id: usize) -> Option<&dyn BodyPart<N>> {
+        self.elements.get(id).map(|e| e as &dyn BodyPart<N>)
     }
 
-    fn world_point_at_material_point(&self, part: &BodyPart<N>, point: &Point3<N>) -> Point3<N> {
+    fn world_point_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point3<N>) -> Point3<N> {
         let elt = part.downcast_ref::<TetrahedralElement<N>>().expect("The provided body part must be tetrahedral element");
         fem_helper::world_point_at_material_point(FiniteElementIndices::Tetrahedron(elt.indices), &self.positions, point)
     }
 
-    fn position_at_material_point(&self, part: &BodyPart<N>, point: &Point3<N>) -> Isometry3<N> {
+    fn position_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point3<N>) -> Isometry3<N> {
         let elt = part.downcast_ref::<TetrahedralElement<N>>().expect("The provided body part must be a tetrahedral element");
         let pt = fem_helper::world_point_at_material_point(FiniteElementIndices::Tetrahedron(elt.indices), &self.positions, point);
         Isometry3::from_parts(Translation3::from(pt.coords), na::one())
     }
 
-    fn material_point_at_world_point(&self, part: &BodyPart<N>, point: &Point3<N>) -> Point3<N> {
+    fn material_point_at_world_point(&self, part: &dyn BodyPart<N>, point: &Point3<N>) -> Point3<N> {
         let elt = part.downcast_ref::<TetrahedralElement<N>>().expect("The provided body part must be tetrahedral element");
         fem_helper::material_point_at_world_point(FiniteElementIndices::Tetrahedron(elt.indices), &self.positions, point)
     }
 
     fn fill_constraint_geometry(
         &self,
-        part: &BodyPart<N>,
+        part: &dyn BodyPart<N>,
         _: usize, // FIXME: keep this parameter?
         center: &Point3<N>,
         force_dir: &ForceDirection<N>,

--- a/src/object/ground.rs
+++ b/src/object/ground.rs
@@ -68,7 +68,7 @@ impl<N: RealField> Body<N> for Ground<N> {
     }
 
     #[inline]
-    fn part(&self, _: usize) -> Option<&BodyPart<N>> {
+    fn part(&self, _: usize) -> Option<&dyn BodyPart<N>> {
         Some(self)
     }
 
@@ -174,17 +174,17 @@ impl<N: RealField> Body<N> for Ground<N> {
     fn set_deactivation_threshold(&mut self, _: Option<N>) {}
 
     #[inline]
-    fn world_point_at_material_point(&self, _: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn world_point_at_material_point(&self, _: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         *point
     }
 
     #[inline]
-    fn position_at_material_point(&self, _: &BodyPart<N>, point: &Point<N>) -> Isometry<N> {
+    fn position_at_material_point(&self, _: &dyn BodyPart<N>, point: &Point<N>) -> Isometry<N> {
         Isometry::from_parts(Translation::from(point.coords), na::one())
     }
 
     #[inline]
-    fn material_point_at_world_point(&self, _: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn material_point_at_world_point(&self, _: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         *point
     }
 
@@ -192,7 +192,7 @@ impl<N: RealField> Body<N> for Ground<N> {
     #[inline]
     fn fill_constraint_geometry(
         &self,
-        _: &BodyPart<N>,
+        _: &dyn BodyPart<N>,
         _: usize, // FIXME: keep this parameter?
         _: &Point<N>,
         _: &ForceDirection<N>,

--- a/src/object/mass_constraint_system.rs
+++ b/src/object/mass_constraint_system.rs
@@ -98,7 +98,7 @@ pub struct MassConstraintSystem<N: RealField> {
     plasticity_creep: N,
     plasticity_max_force: N,
 
-    user_data: Option<Box<Any + Send + Sync>>,
+    user_data: Option<Box<dyn Any + Send + Sync>>,
 }
 
 
@@ -500,8 +500,8 @@ impl<N: RealField> Body<N> for MassConstraintSystem<N> {
         self.velocities.fill(N::zero());
     }
 
-    fn part(&self, id: usize) -> Option<&BodyPart<N>> {
-        self.elements.get(id).map(|e| e as &BodyPart<N>)
+    fn part(&self, id: usize) -> Option<&dyn BodyPart<N>> {
+        self.elements.get(id).map(|e| e as &dyn BodyPart<N>)
     }
 
     fn deformed_positions(&self) -> Option<(DeformationsType, &[N])> {
@@ -513,25 +513,25 @@ impl<N: RealField> Body<N> for MassConstraintSystem<N> {
         Some((DeformationsType::Vectors, self.positions.as_mut_slice()))
     }
 
-    fn world_point_at_material_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn world_point_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         let elt = part.downcast_ref::<MassConstraintElement<N>>().expect("The provided body part must be a mass-constraint element");
         fem_helper::world_point_at_material_point(elt.indices, &self.positions, point)
     }
 
-    fn position_at_material_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Isometry<N> {
+    fn position_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Isometry<N> {
         let elt = part.downcast_ref::<MassConstraintElement<N>>().expect("The provided body part must be a mass-constraint element");
         let pt = fem_helper::world_point_at_material_point(elt.indices, &self.positions, point);
         Isometry::from_parts(Translation::from(pt.coords), na::one())
     }
 
-    fn material_point_at_world_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn material_point_at_world_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         let elt = part.downcast_ref::<MassConstraintElement<N>>().expect("The provided body part must be a mass-constraint element");
         fem_helper::material_point_at_world_point(elt.indices, &self.positions, point)
     }
 
     fn fill_constraint_geometry(
         &self,
-        part: &BodyPart<N>,
+        part: &dyn BodyPart<N>,
         _: usize, // FIXME: keep this parameter?
         center: &Point<N>,
         force_dir: &ForceDirection<N>,

--- a/src/object/mass_spring_system.rs
+++ b/src/object/mass_spring_system.rs
@@ -89,7 +89,7 @@ pub struct MassSpringSystem<N: RealField> {
     plasticity_creep: N,
     plasticity_max_force: N,
 
-    user_data: Option<Box<Any + Send + Sync>>,
+    user_data: Option<Box<dyn Any + Send + Sync>>,
 }
 
 fn key(i: usize, j: usize) -> (usize, usize) {
@@ -597,8 +597,8 @@ impl<N: RealField> Body<N> for MassSpringSystem<N> {
         self.velocities.fill(N::zero());
     }
 
-    fn part(&self, id: usize) -> Option<&BodyPart<N>> {
-        self.elements.get(id).map(|e| e as &BodyPart<N>)
+    fn part(&self, id: usize) -> Option<&dyn BodyPart<N>> {
+        self.elements.get(id).map(|e| e as &dyn BodyPart<N>)
     }
 
     fn deformed_positions(&self) -> Option<(DeformationsType, &[N])> {
@@ -610,25 +610,25 @@ impl<N: RealField> Body<N> for MassSpringSystem<N> {
         Some((DeformationsType::Vectors, self.positions.as_mut_slice()))
     }
 
-    fn world_point_at_material_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn world_point_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         let elt = part.downcast_ref::<MassSpringElement<N>>().expect("The provided body part must be a mass-spring element");
         fem_helper::world_point_at_material_point(elt.indices, &self.positions, point)
     }
 
-    fn position_at_material_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Isometry<N> {
+    fn position_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Isometry<N> {
         let elt = part.downcast_ref::<MassSpringElement<N>>().expect("The provided body part must be a mass-spring element");
         let pt = fem_helper::world_point_at_material_point(elt.indices, &self.positions, point);
         Isometry::from_parts(Translation::from(pt.coords), na::one())
     }
 
-    fn material_point_at_world_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn material_point_at_world_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         let elt = part.downcast_ref::<MassSpringElement<N>>().expect("The provided body part must be a mass-spring element");
         fem_helper::material_point_at_world_point(elt.indices, &self.positions, point)
     }
 
     fn fill_constraint_geometry(
         &self,
-        part: &BodyPart<N>,
+        part: &dyn BodyPart<N>,
         _: usize, // FIXME: keep this parameter?
         center: &Point<N>,
         force_dir: &ForceDirection<N>,

--- a/src/object/multibody.rs
+++ b/src/object/multibody.rs
@@ -36,7 +36,7 @@ pub struct Multibody<N: RealField> {
     activation: ActivationStatus<N>,
     ndofs: usize,
     companion_id: usize,
-    user_data: Option<Box<Any + Send + Sync>>,
+    user_data: Option<Box<dyn Any + Send + Sync>>,
 
     /*
      * Workspaces.
@@ -165,7 +165,7 @@ impl<N: RealField> Multibody<N> {
     fn add_link(
         &mut self,
         parent: BodyPartHandle,
-        mut dof: Box<Joint<N>>,
+        mut dof: Box<dyn Joint<N>>,
         parent_shift: Vector<N>,
         body_shift: Vector<N>,
         local_inertia: Inertia<N>,
@@ -760,8 +760,8 @@ impl<N: RealField> Body<N> for Multibody<N> {
     }
 
     #[inline]
-    fn part(&self, id: usize) -> Option<&BodyPart<N>> {
-        self.link(id).map(|l| l as &BodyPart<N>)
+    fn part(&self, id: usize) -> Option<&dyn BodyPart<N>> {
+        self.link(id).map(|l| l as &dyn BodyPart<N>)
     }
 
     #[inline]
@@ -926,26 +926,26 @@ impl<N: RealField> Body<N> for Multibody<N> {
     }
 
     #[inline]
-    fn world_point_at_material_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn world_point_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         let link = part.downcast_ref::<MultibodyLink<N>>().expect("The provided body part must be a multibody link");
         link.local_to_world * point
     }
 
     #[inline]
-    fn position_at_material_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Isometry<N> {
+    fn position_at_material_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Isometry<N> {
         let link = part.downcast_ref::<MultibodyLink<N>>().expect("The provided body part must be a multibody link");
         link.local_to_world * Translation::from(point.coords)
     }
 
     #[inline]
-    fn material_point_at_world_point(&self, part: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn material_point_at_world_point(&self, part: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         let link = part.downcast_ref::<MultibodyLink<N>>().expect("The provided body part must be a multibody link");
         link.local_to_world.inverse_transform_point(point)
     }
 
     fn fill_constraint_geometry(
         &self,
-        part: &BodyPart<N>,
+        part: &dyn BodyPart<N>,
         ndofs: usize, // FIXME: keep this parameter?
         point: &Point<N>,
         force_dir: &ForceDirection<N>,
@@ -1191,7 +1191,7 @@ impl<N: RealField> Body<N> for Multibody<N> {
 pub struct MultibodyDesc<'a, N: RealField> {
     name: String,
     children: Vec<MultibodyDesc<'a, N>>,
-    joint: Box<Joint<N>>,
+    joint: Box<dyn Joint<N>>,
     velocity: Velocity<N>,
     local_inertia: Inertia<N>,
     local_center_of_mass: Point<N>,

--- a/src/object/multibody_link.rs
+++ b/src/object/multibody_link.rs
@@ -19,7 +19,7 @@ pub struct MultibodyLink<N: RealField> {
     // XXX: rename to "joint".
     // (And rename the full-coordinates joint constraints JointConstraint).
     pub(crate) parent_internal_id: usize,
-    pub(crate) dof: Box<Joint<N>>,
+    pub(crate) dof: Box<dyn Joint<N>>,
     pub(crate) parent_shift: Vector<N>,
     pub(crate) body_shift: Vector<N>,
 
@@ -50,7 +50,7 @@ impl<N: RealField> MultibodyLink<N> {
         impulse_id: usize,
         multibody_handle: BodyHandle,
         parent_internal_id: usize,
-        dof: Box<Joint<N>>,
+        dof: Box<dyn Joint<N>>,
         parent_shift: Vector<N>,
         body_shift: Vector<N>,
         parent_to_world: Isometry<N>,
@@ -98,13 +98,13 @@ impl<N: RealField> MultibodyLink<N> {
 
     /// Reference to the joint attaching this link to its parent.
     #[inline]
-    pub fn joint(&self) -> &Joint<N> {
+    pub fn joint(&self) -> &dyn Joint<N> {
         &*self.dof
     }
 
     /// Mutable reference to the joint attaching this link to its parent.
     #[inline]
-    pub fn joint_mut(&mut self) -> &mut Joint<N> {
+    pub fn joint_mut(&mut self) -> &mut dyn Joint<N> {
         &mut *self.dof
     }
 

--- a/src/object/rigid_body.rs
+++ b/src/object/rigid_body.rs
@@ -37,7 +37,7 @@ pub struct RigidBody<N: RealField> {
     jacobian_mask: SpatialVector<N>,
     companion_id: usize,
     update_status: BodyUpdateStatus,
-    user_data: Option<Box<Any + Send + Sync>>
+    user_data: Option<Box<dyn Any + Send + Sync>>
 }
 
 impl<N: RealField> RigidBody<N> {
@@ -487,7 +487,7 @@ impl<N: RealField> Body<N> for RigidBody<N> {
     }
 
     #[inline]
-    fn part(&self, _: usize) -> Option<&BodyPart<N>> {
+    fn part(&self, _: usize) -> Option<&dyn BodyPart<N>> {
         Some(self)
     }
 
@@ -497,17 +497,17 @@ impl<N: RealField> Body<N> for RigidBody<N> {
     }
 
     #[inline]
-    fn world_point_at_material_point(&self, _: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn world_point_at_material_point(&self, _: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         self.position * point
     }
 
     #[inline]
-    fn position_at_material_point(&self, _: &BodyPart<N>, point: &Point<N>) -> Isometry<N> {
+    fn position_at_material_point(&self, _: &dyn BodyPart<N>, point: &Point<N>) -> Isometry<N> {
         self.position * Translation::from(point.coords)
     }
 
     #[inline]
-    fn material_point_at_world_point(&self, _: &BodyPart<N>, point: &Point<N>) -> Point<N> {
+    fn material_point_at_world_point(&self, _: &dyn BodyPart<N>, point: &Point<N>) -> Point<N> {
         self.position.inverse_transform_point(point)
     }
 
@@ -524,7 +524,7 @@ impl<N: RealField> Body<N> for RigidBody<N> {
     #[inline]
     fn fill_constraint_geometry(
         &self,
-        _: &BodyPart<N>,
+        _: &dyn BodyPart<N>,
         _: usize,
         point: &Point<N>,
         force_dir: &ForceDirection<N>,

--- a/src/solver/helper.rs
+++ b/src/solver/helper.rs
@@ -581,10 +581,10 @@ pub fn cancel_relative_rotation<N: RealField>(
 /// All inputs mut be given in world-space.
 #[cfg(feature = "dim3")]
 pub fn restrict_relative_angular_velocity_to_axis<N: RealField>(
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     assembly_id1: usize,
     assembly_id2: usize,
     axis: &Unit<AngularVector<N>>,
@@ -665,10 +665,10 @@ pub fn restrict_relative_angular_velocity_to_axis<N: RealField>(
 #[cfg(feature = "dim3")]
 pub fn align_axis<N: RealField>(
     params: &IntegrationParameters<N>,
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     anchor1: &Point<N>,
     anchor2: &Point<N>,
     axis1: &Unit<Vector<N>>,
@@ -873,10 +873,10 @@ pub fn project_anchor_to_axis<N: RealField>(
 #[cfg(feature = "dim3")]
 pub fn restore_angle_between_axis<N: RealField>(
     params: &IntegrationParameters<N>,
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     anchor1: &Point<N>,
     anchor2: &Point<N>,
     axis1: &Unit<Vector<N>>,

--- a/src/solver/helper.rs
+++ b/src/solver/helper.rs
@@ -54,10 +54,10 @@ impl<N: RealField> Neg for ForceDirection<N> {
 /// Every input are expressed in world-space.
 #[inline]
 pub fn constraint_pair_geometry<N: RealField>(
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     center1: &Point<N>,
     center2: &Point<N>,
     dir: &ForceDirection<N>,
@@ -139,8 +139,8 @@ pub fn constraint_pair_geometry<N: RealField>(
 /// constraint (a constraint between a dynamic body and one without any degree of freedom).
 #[inline]
 pub fn constraints_are_ground_constraints<N: RealField>(
-    body1: &Body<N>,
-    body2: &Body<N>,
+    body1: &dyn Body<N>,
+    body2: &dyn Body<N>,
 ) -> bool {
     body1.status_dependent_ndofs() == 0 || body2.status_dependent_ndofs() == 0
 }
@@ -148,8 +148,8 @@ pub fn constraints_are_ground_constraints<N: RealField>(
 /// Retrieve the external velocity subvectors for the given bodies.
 #[inline(always)]
 pub fn split_ext_vels<'a, N: RealField>(
-    body1: &Body<N>,
-    body2: &Body<N>,
+    body1: &dyn Body<N>,
+    body2: &dyn Body<N>,
     assembly_id1: usize,
     assembly_id2: usize,
     ext_vels: &'a DVector<N>)
@@ -164,10 +164,10 @@ pub fn split_ext_vels<'a, N: RealField>(
 ///
 /// All inputs mut be given in world-space.
 pub fn cancel_relative_linear_velocity_wrt_axis<N: RealField>(
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     assembly_id1: usize,
     assembly_id2: usize,
     anchor1: &Point<N>,
@@ -239,10 +239,10 @@ pub fn cancel_relative_linear_velocity_wrt_axis<N: RealField>(
 ///
 /// All inputs mut be given in world-space.
 pub fn cancel_relative_linear_velocity<N: RealField>(
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     assembly_id1: usize,
     assembly_id2: usize,
     anchor1: &Point<N>,
@@ -287,10 +287,10 @@ pub fn cancel_relative_linear_velocity<N: RealField>(
 /// All inputs mut be given in world-space.
 pub fn cancel_relative_translation_wrt_axis<N: RealField>(
     params: &IntegrationParameters<N>,
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     anchor1: &Point<N>,
     anchor2: &Point<N>,
     axis: &Unit<Vector<N>>,
@@ -349,10 +349,10 @@ pub fn cancel_relative_translation_wrt_axis<N: RealField>(
 /// All inputs mut be given in world-space.
 pub fn cancel_relative_translation<N: RealField>(
     params: &IntegrationParameters<N>,
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     anchor1: &Point<N>,
     anchor2: &Point<N>,
     jacobians: &mut [N],
@@ -402,10 +402,10 @@ pub fn cancel_relative_translation<N: RealField>(
 ///
 /// All inputs mut be given in world-space.
 pub fn cancel_relative_angular_velocity_wrt_axis<N: RealField>(
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     assembly_id1: usize,
     assembly_id2: usize,
     anchor1: &Point<N>,
@@ -477,10 +477,10 @@ pub fn cancel_relative_angular_velocity_wrt_axis<N: RealField>(
 ///
 /// All inputs mut be given in world-space.
 pub fn cancel_relative_angular_velocity<N: RealField>(
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     assembly_id1: usize,
     assembly_id2: usize,
     anchor1: &Point<N>,
@@ -525,10 +525,10 @@ pub fn cancel_relative_angular_velocity<N: RealField>(
 /// All inputs mut be given in world-space.
 pub fn cancel_relative_rotation<N: RealField>(
     params: &IntegrationParameters<N>,
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     anchor1: &Point<N>,
     anchor2: &Point<N>,
     rotation1: &Rotation<N>,
@@ -730,10 +730,10 @@ pub fn align_axis<N: RealField>(
 ///
 /// All inputs mut be given in world-space.
 pub fn restrict_relative_linear_velocity_to_axis<N: RealField>(
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     assembly_id1: usize,
     assembly_id2: usize,
     anchor1: &Point<N>,
@@ -814,10 +814,10 @@ pub fn restrict_relative_linear_velocity_to_axis<N: RealField>(
 /// All inputs mut be given in world-space.
 pub fn project_anchor_to_axis<N: RealField>(
     params: &IntegrationParameters<N>,
-    body1: &Body<N>,
-    part1: &BodyPart<N>,
-    body2: &Body<N>,
-    part2: &BodyPart<N>,
+    body1: &dyn Body<N>,
+    part1: &dyn BodyPart<N>,
+    body2: &dyn Body<N>,
+    part2: &dyn BodyPart<N>,
     anchor1: &Point<N>,
     anchor2: &Point<N>,
     axis1: &Unit<Vector<N>>,

--- a/src/solver/moreau_jean_solver.rs
+++ b/src/solver/moreau_jean_solver.rs
@@ -16,14 +16,14 @@ pub struct MoreauJeanSolver<N: RealField> {
     // FIXME: use a Vec or a DVector?
     mj_lambda_vel: DVector<N>,
     ext_vels: DVector<N>,
-    contact_model: Box<ContactModel<N>>,
+    contact_model: Box<dyn ContactModel<N>>,
     constraints: ConstraintSet<N>,
     internal_constraints: Vec<BodyHandle>,
 }
 
 impl<N: RealField> MoreauJeanSolver<N> {
     /// Create a new time-stepping scheme with the given contact model.
-    pub fn new(contact_model: Box<ContactModel<N>>) -> Self {
+    pub fn new(contact_model: Box<dyn ContactModel<N>>) -> Self {
         let constraints = ConstraintSet::new();
 
         MoreauJeanSolver {
@@ -37,7 +37,7 @@ impl<N: RealField> MoreauJeanSolver<N> {
     }
 
     /// Sets the contact model.
-    pub fn set_contact_model(&mut self, model: Box<ContactModel<N>>) {
+    pub fn set_contact_model(&mut self, model: Box<dyn ContactModel<N>>) {
         self.contact_model = model
     }
 
@@ -46,7 +46,7 @@ impl<N: RealField> MoreauJeanSolver<N> {
         &mut self,
         counters: &mut Counters,
         bodies: &mut BodySet<N>,
-        joints: &mut Slab<Box<JointConstraint<N>>>,
+        joints: &mut Slab<Box<dyn JointConstraint<N>>>,
         manifolds: &[ColliderContactManifold<N>],
         island: &[BodyHandle],
         params: &IntegrationParameters<N>,
@@ -79,7 +79,7 @@ impl<N: RealField> MoreauJeanSolver<N> {
         params: &IntegrationParameters<N>,
         coefficients: &MaterialsCoefficientsTable<N>,
         bodies: &mut BodySet<N>,
-        joints: &mut Slab<Box<JointConstraint<N>>>,
+        joints: &mut Slab<Box<dyn JointConstraint<N>>>,
         manifolds: &[ColliderContactManifold<N>],
         island: &[BodyHandle],
     ) {
@@ -225,7 +225,7 @@ impl<N: RealField> MoreauJeanSolver<N> {
         params: &IntegrationParameters<N>,
         cworld: &ColliderWorld<N>,
         bodies: &mut BodySet<N>,
-        joints: &mut Slab<Box<JointConstraint<N>>>,
+        joints: &mut Slab<Box<dyn JointConstraint<N>>>,
     ) {
         NonlinearSORProx::solve(
             params,
@@ -242,7 +242,7 @@ impl<N: RealField> MoreauJeanSolver<N> {
     fn save_cache(
         &mut self,
         bodies: &mut BodySet<N>,
-        joints: &mut Slab<Box<JointConstraint<N>>>,
+        joints: &mut Slab<Box<dyn JointConstraint<N>>>,
     ) {
         self.contact_model.cache_impulses(&self.constraints);
 

--- a/src/solver/nonlinear_sor_prox.rs
+++ b/src/solver/nonlinear_sor_prox.rs
@@ -19,7 +19,7 @@ impl NonlinearSORProx {
         cworld: &ColliderWorld<N>,
         bodies: &mut BodySet<N>,
         constraints: &mut [NonlinearUnilateralConstraint<N>],
-        joints_constraints: &Slab<Box<JointConstraint<N>>>, // FIXME: ugly, use a slice of refs instead.
+        joints_constraints: &Slab<Box<dyn JointConstraint<N>>>, // FIXME: ugly, use a slice of refs instead.
         internal_constraints: &[BodyHandle],
         jacobians: &mut [N],
         max_iter: usize,

--- a/src/solver/signorini_model.rs
+++ b/src/solver/signorini_model.rs
@@ -32,10 +32,10 @@ impl<N: RealField> SignoriniModel<N> {
     /// Build a non-penetration velocity-based constraint for the given contact.
     pub fn build_velocity_constraint(
         params: &IntegrationParameters<N>,
-        body1: &Body<N>,
-        part1: &BodyPart<N>,
-        body2: &Body<N>,
-        part2: &BodyPart<N>,
+        body1: &dyn Body<N>,
+        part1: &dyn BodyPart<N>,
+        body2: &dyn Body<N>,
+        part2: &dyn BodyPart<N>,
         props: &LocalMaterialProperties<N>,
         manifold: &ColliderContactManifold<N>,
         ext_vels: &DVector<N>,

--- a/src/utils/user_data.rs
+++ b/src/utils/user_data.rs
@@ -4,26 +4,26 @@ use std::any::Any;
 /// Trait to be implemented by user-defined data.
 pub trait UserData: Any + Send + Sync {
     /// Clone this trait-object.
-    fn clone_boxed(&self) -> Box<UserData>;
+    fn clone_boxed(&self) -> Box<dyn UserData>;
     /// Clone as its super-trait trait objects.
-    fn to_any(&self) -> Box<Any + Send + Sync>;
+    fn to_any(&self) -> Box<dyn Any + Send + Sync>;
     /// Downcast to Any.
-    fn as_any(&self) -> &(Any + Send + Sync);
+    fn as_any(&self) -> &(dyn Any + Send + Sync);
 }
 
 impl<T: Clone + Any + Send + Sync> UserData for T {
     #[inline]
-    fn clone_boxed(&self) -> Box<UserData> {
+    fn clone_boxed(&self) -> Box<dyn UserData> {
         Box::new(self.clone())
     }
 
     #[inline]
-    fn to_any(&self) -> Box<Any + Send + Sync> {
+    fn to_any(&self) -> Box<dyn Any + Send + Sync> {
         Box::new(self.clone())
     }
 
     #[inline]
-    fn as_any(&self) -> &(Any + Send + Sync) {
+    fn as_any(&self) -> &(dyn Any + Send + Sync) {
         self
     }
 }
@@ -31,7 +31,7 @@ impl<T: Clone + Any + Send + Sync> UserData for T {
 // We need this because we must not implement Clone for Box<UserData>
 // directly otherwise Box<UserData> would implement UserData too and
 // we want to avoid the user mistakenly nesting user-datas.
-pub(crate) struct UserDataBox(pub Box<UserData>);
+pub(crate) struct UserDataBox(pub Box<dyn UserData>);
 
 impl Clone for UserDataBox {
     #[inline]

--- a/src/volumetric/volumetric_convex2.rs
+++ b/src/volumetric/volumetric_convex2.rs
@@ -156,9 +156,9 @@ impl<N: RealField> Volumetric<N> for ConvexPolygon<N> {
 
 #[cfg(test)]
 mod test {
-    use na::{self, Matrix1, Point2, Vector2, Vector3};
+    use na::{self, Matrix1, Point2, Vector2};
     use ncollide::shape::{Cuboid, ConvexPolygon};
-    use ncollide::procedural;
+    
     use crate::volumetric::Volumetric;
 
     #[test]

--- a/src/volumetric/volumetric_shape.rs
+++ b/src/volumetric/volumetric_shape.rs
@@ -49,7 +49,7 @@ macro_rules! dispatch(
     }
 );
 
-impl<N: RealField> Volumetric<N> for Shape<N> {
+impl<N: RealField> Volumetric<N> for dyn Shape<N> {
     fn area(&self) -> N {
         dispatch!(Point<N>, AngularInertia<N>, self.area())
     }

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -30,8 +30,8 @@ pub struct World<N: RealField> {
     // FIXME: set those two parameters per-collider?
     prediction: N,
     gravity: Vector<N>,
-    constraints: Slab<Box<JointConstraint<N>>>,
-    forces: Slab<Box<ForceGenerator<N>>>,
+    constraints: Slab<Box<dyn JointConstraint<N>>>,
+    forces: Slab<Box<dyn ForceGenerator<N>>>,
     params: IntegrationParameters<N>,
 }
 
@@ -149,12 +149,12 @@ impl<N: RealField> World<N> {
     }
 
     /// Get a reference to the specified constraint.
-    pub fn constraint(&self, handle: ConstraintHandle) -> &JointConstraint<N> {
+    pub fn constraint(&self, handle: ConstraintHandle) -> &dyn JointConstraint<N> {
         &*self.constraints[handle]
     }
 
     /// Get a mutable reference to the specified constraint.
-    pub fn constraint_mut(&mut self, handle: ConstraintHandle) -> &mut JointConstraint<N> {
+    pub fn constraint_mut(&mut self, handle: ConstraintHandle) -> &mut dyn JointConstraint<N> {
         let (anchor1, anchor2) = self.constraints[handle].anchors();
         self.activate_body(anchor1.0);
         self.activate_body(anchor2.0);
@@ -162,7 +162,7 @@ impl<N: RealField> World<N> {
     }
 
     /// Remove the specified constraint from the world.
-    pub fn remove_constraint(&mut self, handle: ConstraintHandle) -> Box<JointConstraint<N>> {
+    pub fn remove_constraint(&mut self, handle: ConstraintHandle) -> Box<dyn JointConstraint<N>> {
         let constraint = self.constraints.remove(handle);
         let (anchor1, anchor2) = constraint.anchors();
         self.activate_body(anchor1.0);
@@ -197,12 +197,12 @@ impl<N: RealField> World<N> {
     }
 
     /// Retrieve a reference to the specified force generator.
-    pub fn force_generator(&self, handle: ForceGeneratorHandle) -> &ForceGenerator<N> {
+    pub fn force_generator(&self, handle: ForceGeneratorHandle) -> &dyn ForceGenerator<N> {
         &*self.forces[handle]
     }
 
     /// Retrieve a mutable reference to the specified force generator.
-    pub fn force_generator_mut(&mut self, handle: ForceGeneratorHandle) -> &mut ForceGenerator<N> {
+    pub fn force_generator_mut(&mut self, handle: ForceGeneratorHandle) -> &mut dyn ForceGenerator<N> {
         &mut *self.forces[handle]
     }
 
@@ -210,7 +210,7 @@ impl<N: RealField> World<N> {
     pub fn remove_force_generator(
         &mut self,
         handle: ForceGeneratorHandle,
-    ) -> Box<ForceGenerator<N>> {
+    ) -> Box<dyn ForceGenerator<N>> {
         self.forces.remove(handle)
     }
 
@@ -425,12 +425,12 @@ impl<N: RealField> World<N> {
     }
 
     /// Get a reference to the specified body.
-    pub fn body(&self, handle: BodyHandle) -> Option<&Body<N>> {
+    pub fn body(&self, handle: BodyHandle) -> Option<&dyn Body<N>> {
         self.bodies.body(handle)
     }
 
     /// Get a mutable reference to the specified body.
-    pub fn body_mut(&mut self, handle: BodyHandle) -> Option<&mut Body<N>> {
+    pub fn body_mut(&mut self, handle: BodyHandle) -> Option<&mut dyn Body<N>> {
         self.bodies.body_mut(handle)
     }
 
@@ -511,18 +511,18 @@ impl<N: RealField> World<N> {
     }
 
     /// An iterator through all the bodies on this world.
-    pub fn bodies(&self) -> impl Iterator<Item = &Body<N>> { self.bodies.bodies() }
+    pub fn bodies(&self) -> impl Iterator<Item = &dyn Body<N>> { self.bodies.bodies() }
 
     /// A mutable iterator through all the bodies on this world.
-    pub fn bodies_mut(&mut self) -> impl Iterator<Item = &mut Body<N>> { self.bodies.bodies_mut() }
+    pub fn bodies_mut(&mut self) -> impl Iterator<Item = &mut dyn Body<N>> { self.bodies.bodies_mut() }
 
     /// An iterator through all the bodies with the given name.
-    pub fn bodies_with_name<'a>(&'a self, name: &'a str) -> impl Iterator<Item = &'a Body<N>> {
+    pub fn bodies_with_name<'a>(&'a self, name: &'a str) -> impl Iterator<Item = &'a dyn Body<N>> {
         self.bodies().filter(move |b| b.name() == name)
     }
 
     /// An iterator through all the bodies with the given name.
-    pub fn bodies_with_name_mut<'a>(&'a mut self, name: &'a str) -> impl Iterator<Item = &'a mut Body<N>> {
+    pub fn bodies_with_name_mut<'a>(&'a mut self, name: &'a str) -> impl Iterator<Item = &'a mut dyn Body<N>> {
         self.bodies_mut().filter(move |b| b.name() == name)
     }
 
@@ -549,6 +549,6 @@ mod test {
 
     #[test]
     fn world_is_send_sync() {
-        let _ = Box::new(World::<f32>::new()) as Box<Send + Sync>;
+        let _ = Box::new(World::<f32>::new()) as Box<dyn Send + Sync>;
     }
 }


### PR DESCRIPTION
So I noticed there doesn't seem to be much work going on here at the moment and figured this *might* be a good time to make this PR since the likelyhood of massive quantities of merge conflicts is severely reduced. If this is not the right time then feel free to close this PR and schedule these changes for another time, all changes were made completely automated by running `cargo fix` after adding `#![deny(bare_trait_objects)]` to lib.rs.

rustsim/ncollide#297 provides a bit of background for the reasons why it's preferable to enforce `dyn` in front of every trait-object but in short it enhances their visibility by distinguishing them from structs.