### PR TITLE
Loosen generics on MechanicalWorld

### DIFF
--- a/src/solver/contact_model.rs
+++ b/src/solver/contact_model.rs
@@ -1,34 +1,31 @@
 #![allow(missing_docs)]
 
-use downcast_rs::Downcast;
 use na::{DVector, RealField};
 use ncollide::query::ContactId;
 
 use crate::detection::ColliderContactManifold;
-use crate::object::{BodySet, ColliderHandle};
+use crate::object::{BodySet, ColliderHandle, BodyHandle};
 use crate::material::MaterialsCoefficientsTable;
 use crate::solver::{ConstraintSet, IntegrationParameters};
 
 /// The modeling of a contact.
-pub trait ContactModel<N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle>: Downcast + Send + Sync {
+pub trait ContactModel<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>: Send + Sync {
     /// Maximum number of velocity constraint to be generated for each contact.
-    fn num_velocity_constraints(&self, manifold: &ColliderContactManifold<N, Bodies::Handle, CollHandle>) -> usize;
+    fn num_velocity_constraints(&self, manifold: &ColliderContactManifold<N, Handle, CollHandle>) -> usize;
     /// Generate all constraints for the given contact manifolds.
-    fn constraints(
+    fn constraints<Bodies: BodySet<N, Handle=Handle>>(
         &mut self,
         parameters: &IntegrationParameters<N>,
         material_coefficients: &MaterialsCoefficientsTable<N>,
         bodies: &Bodies,
         ext_vels: &DVector<N>,
-        manifolds: &[ColliderContactManifold<N, Bodies::Handle, CollHandle>],
+        manifolds: &[ColliderContactManifold<N, Handle, CollHandle>],
         ground_j_id: &mut usize,
         j_id: &mut usize,
         jacobians: &mut [N],
-        constraints: &mut ConstraintSet<N, Bodies::Handle, CollHandle, ContactId>,
+        constraints: &mut ConstraintSet<N, Handle, CollHandle, ContactId>,
     );
 
     /// Stores all the impulses found by the solver into a cache for warmstarting.
-    fn cache_impulses(&mut self, constraints: &ConstraintSet<N, Bodies::Handle, CollHandle, ContactId>);
+    fn cache_impulses(&mut self, constraints: &ConstraintSet<N, Handle, CollHandle, ContactId>);
 }
-
-impl_downcast!(ContactModel<N, Bodies, CollHandle> where N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle);

--- a/src/solver/signorini_coulomb_pyramid_model.rs
+++ b/src/solver/signorini_coulomb_pyramid_model.rs
@@ -6,7 +6,7 @@ use ncollide::query::ContactId;
 
 use crate::detection::ColliderContactManifold;
 use crate::math::{Vector, DIM};
-use crate::object::{BodySet, Body, ColliderHandle};
+use crate::object::{BodySet, Body, ColliderHandle, BodyHandle};
 use crate::material::{Material, MaterialContext, MaterialsCoefficientsTable};
 use crate::solver::helper;
 use crate::solver::{
@@ -44,22 +44,22 @@ impl<N: RealField> Default for SignoriniCoulombPyramidModel<N> {
     }
 }
 
-impl<N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle> ContactModel<N, Bodies, CollHandle> for SignoriniCoulombPyramidModel<N> {
-    fn num_velocity_constraints(&self, c: &ColliderContactManifold<N, Bodies::Handle, CollHandle>) -> usize {
+impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle> ContactModel<N, Handle, CollHandle> for SignoriniCoulombPyramidModel<N> {
+    fn num_velocity_constraints(&self, c: &ColliderContactManifold<N, Handle, CollHandle>) -> usize {
         DIM * c.len()
     }
 
-    fn constraints(
+    fn constraints<Bodies: BodySet<N, Handle=Handle>>(
         &mut self,
         parameters: &IntegrationParameters<N>,
         coefficients: &MaterialsCoefficientsTable<N>,
         bodies: &Bodies,
         ext_vels: &DVector<N>,
-        manifolds: &[ColliderContactManifold<N, Bodies::Handle, CollHandle>],
+        manifolds: &[ColliderContactManifold<N, Handle, CollHandle>],
         ground_j_id: &mut usize,
         j_id: &mut usize,
         jacobians: &mut [N],
-        constraints: &mut ConstraintSet<N, Bodies::Handle, CollHandle, ContactId>,
+        constraints: &mut ConstraintSet<N, Handle, CollHandle, ContactId>,
     ) {
         let id_vel_ground = constraints.velocity.unilateral_ground.len();
         let id_vel = constraints.velocity.unilateral.len();
@@ -200,7 +200,7 @@ impl<N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle> ContactModel<
         self.friction_rng = id_friction..constraints.velocity.bilateral.len();
     }
 
-    fn cache_impulses(&mut self, constraints: &ConstraintSet<N, Bodies::Handle, CollHandle, ContactId>) {
+    fn cache_impulses(&mut self, constraints: &ConstraintSet<N, Handle, CollHandle, ContactId>) {
         let ground_contacts = &constraints.velocity.unilateral_ground[self.vel_ground_rng.clone()];
         let contacts = &constraints.velocity.unilateral[self.vel_rng.clone()];
         let ground_friction =

--- a/src/solver/signorini_model.rs
+++ b/src/solver/signorini_model.rs
@@ -190,22 +190,22 @@ impl<N: RealField> SignoriniModel<N> {
     }
 }
 
-impl<N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle> ContactModel<N, Bodies, CollHandle> for SignoriniModel<N> {
-    fn num_velocity_constraints(&self, c: &ColliderContactManifold<N, Bodies::Handle, CollHandle>) -> usize {
+impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle> ContactModel<N, Handle, CollHandle> for SignoriniModel<N> {
+    fn num_velocity_constraints(&self, c: &ColliderContactManifold<N, Handle, CollHandle>) -> usize {
         c.manifold.len()
     }
 
-    fn constraints(
+    fn constraints<Bodies: BodySet<N, Handle=Handle>>(
         &mut self,
         parameters: &IntegrationParameters<N>,
         coefficients: &MaterialsCoefficientsTable<N>,
         bodies: &Bodies,
         ext_vels: &DVector<N>,
-        manifolds: &[ColliderContactManifold<N, Bodies::Handle, CollHandle>],
+        manifolds: &[ColliderContactManifold<N, Handle, CollHandle>],
         ground_j_id: &mut usize,
         j_id: &mut usize,
         jacobians: &mut [N],
-        constraints: &mut ConstraintSet<N, Bodies::Handle, CollHandle, ContactId>,
+        constraints: &mut ConstraintSet<N, Handle, CollHandle, ContactId>,
     ) {
         let id_vel_ground = constraints.velocity.unilateral_ground.len();
         let id_vel = constraints.velocity.unilateral.len();
@@ -257,7 +257,7 @@ impl<N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle> ContactModel<
         self.vel_rng = id_vel..constraints.velocity.unilateral.len();
     }
 
-    fn cache_impulses(&mut self, constraints: &ConstraintSet<N, Bodies::Handle, CollHandle, ContactId>) {
+    fn cache_impulses(&mut self, constraints: &ConstraintSet<N, Handle, CollHandle, ContactId>) {
         let ground_contacts = &constraints.velocity.unilateral_ground[self.vel_ground_rng.clone()];
         let contacts = &constraints.velocity.unilateral[self.vel_rng.clone()];
 


### PR DESCRIPTION
`MechanicalWorld` had limiting generics that could be further restricted.
```rust
// Before
MechanicalWorld<N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle>
// After
MechanicalWorld<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
// As an added bonus of this, generics are now consistent across both worlds
GeometricalWorld<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
```
`MechanicalWorld` was generic over `BodySet<N>` to satisfy `MoreauJeanSolver`'s contact model `Box<dyn ContactModel<N, Bodies, CollHandle>>`. However by using a dynamic contact model trait, `ContactModel` could not have any function level generics and was forced to add `Bodies: BodySet<N>` as a trait level generic. To achieve this I made the contact model generic in the solver.

#### Side Effects
 - `MoreauJeanSolver::set_contact_model` was removed. Calling this function while the physics engine is running would likely cause errors anyway (speculation) and it can now be changed with the generic on `MoreauJeanSolver` if necessary.
 - The requirement of `Downcast` on `ContactModel` was removed since it is no longer necessary.

#### Motivation
This generic added lifetime requirements to the world that made ECS even more difficult to implement.