### PR TITLE
Fixes rustsim/nphysics#227

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ mesh2d
 ragdoll3d
 ragdoll2d
 Cargo.lock
+.vscode/
+.idea/


### PR DESCRIPTION
Add `.idea/` and `.vscode/` to the `.gitignore`. My original issue only mentioned `.idea`, but I later decided to also include `.vscode` to cover both IDEs and due to it's use in all other rustsim repositories.