### PR TITLE
Remove unsafe code from body and collider sets

### DIFF
--- a/src/object/body_set.rs
+++ b/src/object/body_set.rs
@@ -28,10 +28,7 @@ pub trait BodySet<N: RealField> {
     fn get(&self, handle: Self::Handle) -> Option<&Self::Body>;
     /// Gets a mutable reference to the body identified by `handle`.
     fn get_mut(&mut self, handle: Self::Handle) -> Option<&mut Self::Body>;
-    /// Gets a mutable reference to the two bodies identified by `handle1` and `handle2`.
-    ///
-    /// Panics if both handles are equal.
-    fn get_pair_mut(&mut self, handle1: Self::Handle, handle2: Self::Handle) -> (Option<&mut Self::Body>, Option<&mut Self::Body>);
+
     /// Gets a reference to the two bodies identified by `handle1` and `handle2`.
     ///
     /// Both handles are allowed to be equal.
@@ -156,20 +153,6 @@ impl<N: RealField> BodySet<N> for DefaultBodySet<N> {
     fn get_mut(&mut self, handle: Self::Handle) -> Option<&mut Self::Body> {
         self.get_mut(handle)
     }
-
-    fn get_pair_mut(&mut self, handle1: Self::Handle, handle2: Self::Handle) -> (Option<&mut Self::Body>, Option<&mut Self::Body>) {
-        assert_ne!(handle1, handle2, "Both body handles must not be equal.");
-        let b1 = self.get_mut(handle1).map(|b| b as *mut dyn Body<N>);
-        let b2 = self.get_mut(handle2).map(|b| b as *mut dyn Body<N>);
-        unsafe {
-            use std::mem;
-            (
-                b1.map(|b| mem::transmute(b)),
-                b2.map(|b| mem::transmute(b))
-            )
-        }
-    }
-
 
     fn contains(&self, handle: Self::Handle) -> bool {
         self.contains(handle)

--- a/src/object/collider_set.rs
+++ b/src/object/collider_set.rs
@@ -26,10 +26,7 @@ pub trait ColliderSet<N: RealField, Handle: BodyHandle>: CollisionObjectSet<N, C
     fn get(&self, handle: Self::Handle) -> Option<&Collider<N, Handle>>;
     /// Gets a mutable reference to the collider identified by `handle`.
     fn get_mut(&mut self, handle: Self::Handle) -> Option<&mut Collider<N, Handle>>;
-    /// Gets a mutable reference to the two colliders identified by `handle1` and `handle2`.
-    ///
-    /// Panics if both handles are equal.
-    fn get_pair_mut(&mut self, handle1: Self::Handle, handle2: Self::Handle) -> (Option<&mut Collider<N, Handle>>, Option<&mut Collider<N, Handle>>);
+
     /// Gets a reference to the two colliders identified by `handle1` and `handle2`.
     ///
     /// Both handles are allowed to be equal.
@@ -64,7 +61,7 @@ pub trait ColliderSet<N: RealField, Handle: BodyHandle>: CollisionObjectSet<N, C
     fn pop_removal_event(&mut self) -> Option<(Self::Handle, ColliderRemovalData<N, Handle>)>;
     /// Removes a collider from this set.
     ///
-    /// A collider can be removed automatically by nphysics whene the collider it was attached too has been removed.
+    /// A collider can be removed automatically by nphysics when the collider it was attached too has been removed.
     fn remove(&mut self, to_remove: Self::Handle) -> Option<&mut ColliderRemovalData<N, Handle>>;
 }
 
@@ -160,16 +157,6 @@ impl<N: RealField, Handle: BodyHandle> ColliderSet<N, Handle> for DefaultCollide
 
     fn get_mut(&mut self, handle: Self::Handle) -> Option<&mut Collider<N, Handle>> {
         self.get_mut(handle)
-    }
-
-    fn get_pair_mut(&mut self, handle1: Self::Handle, handle2: Self::Handle) -> (Option<&mut Collider<N, Handle>>, Option<&mut Collider<N, Handle>>) {
-        assert_ne!(handle1, handle2, "Both body handles must not be equal.");
-        let b1 = self.get_mut(handle1).map(|b| b as *mut Collider<N, Handle>);
-        let b2 = self.get_mut(handle2).map(|b| b as *mut Collider<N, Handle>);
-        unsafe {
-            use std::mem;
-            (b1.map(|b| mem::transmute(b)), b2.map(|b| mem::transmute(b)))
-        }
     }
 
     fn contains(&self, handle: Self::Handle) -> bool {

--- a/src/world/mechanical_world.rs
+++ b/src/world/mechanical_world.rs
@@ -662,7 +662,7 @@ impl<N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle> MechanicalWor
                                         let needs_prep = b2.companion_id() == 0 && b2.is_dynamic();
 
                                         if needs_prep {
-                                            prepare_body(handle1, b2, colliders.get_mut(ch2).unwrap())
+                                            prepare_body(handle2, b2, colliders.get_mut(ch2).unwrap())
                                         }
                                         needs_prep
                                     };


### PR DESCRIPTION
The methods `BodySet::get_pair_mut` and `ColliderSet::get_pair_mut` used unsafe code to get two multiple mutable references from a pair of unique handles. In many cases this forces anyone implementing their own `BodySet` or `ColliderSet` to also use unsafe code that could have been avoided. However these functions are not necessary and the same effect can be achieved at the cost of 2 extra calls to `ColliderSet::get_pair`.

This change should have an insignificant effect on performance that might be optimized out.

In order to reflect the original functionality, I modified the if statement slightly. I did not look back far enough in the file to check, but seems likely that the if statement is no longer necessary.
```rust
// Before
 if let (Some(b1), Some(b2)) = bodies.get_pair_mut(handle1, handle2) {}
// After
if bodies.contains(handle1) && bodies.contains(handle2) {
// each body is then retrieved once using bodies.get_mut(handle).unwrap()
}
```
