### PR TITLE
Utilize BodySet as a trait object instead of param

### DIFF
--- a/src/detection/activation_manager.rs
+++ b/src/detection/activation_manager.rs
@@ -58,17 +58,16 @@ impl<N: RealField, Handle: BodyHandle> ActivationManager<N, Handle> {
     }
 
     /// Update the activation manager, activating and deactivating objects when needed.
-    pub fn update<Bodies, Colliders, Constraints>(
+    pub fn update<Colliders, Constraints>(
         &mut self,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         colliders: &Colliders,
         gworld: &GeometricalWorld<N, Handle, Colliders::Handle>,
         constraints: &Constraints,
         active_bodies: &mut Vec<Handle>,
     ) where
-        Bodies: BodySet<N, Handle = Handle>,
         Colliders: ColliderSet<N, Handle>,
-        Constraints: JointConstraintSet<N, Bodies>,
+        Constraints: JointConstraintSet<N, Handle>,
     {
         /*
          *
@@ -77,7 +76,7 @@ impl<N: RealField, Handle: BodyHandle> ActivationManager<N, Handle> {
          */
         self.id_to_body.clear();
 
-        bodies.foreach_mut(|handle, body| {
+        bodies.foreach_mut(&mut |handle, body: &mut dyn Body<N>| {
             if body.status_dependent_ndofs() != 0 {
                 if body.is_active() {
                     self.update_energy(body);
@@ -131,10 +130,10 @@ impl<N: RealField, Handle: BodyHandle> ActivationManager<N, Handle> {
         // Run the union-find.
         // FIXME: use the union-find from petgraph?
         #[inline(always)]
-        fn make_union<N: RealField, Bodies: BodySet<N>>(
-            bodies: &Bodies,
-            b1: Bodies::Handle,
-            b2: Bodies::Handle,
+        fn make_union<N: RealField, Handle: BodyHandle>(
+            bodies: &dyn BodySet<N, Handle = Handle>,
+            b1: Handle,
+            b2: Handle,
             ufs: &mut [UnionFindSet],
         ) {
             let b1 = try_ret!(bodies.get(b1));

--- a/src/force_generator/constant_acceleration.rs
+++ b/src/force_generator/constant_acceleration.rs
@@ -2,7 +2,7 @@ use na::RealField;
 
 use crate::force_generator::ForceGenerator;
 use crate::math::{Force, ForceType, Vector, Velocity};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::IntegrationParameters;
 
 /// Force generator adding a constant acceleration
@@ -41,10 +41,14 @@ impl<N: RealField, Handle: BodyHandle> ConstantAcceleration<N, Handle> {
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    ForceGenerator<N, Bodies> for ConstantAcceleration<N, Handle>
+impl<N: RealField, Handle: BodyHandle> ForceGenerator<N, Handle>
+    for ConstantAcceleration<N, Handle>
 {
-    fn apply(&mut self, _: &IntegrationParameters<N>, bodies: &mut Bodies) {
+    fn apply(
+        &mut self,
+        _: &IntegrationParameters<N>,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
+    ) {
         let acceleration = self.acceleration;
         self.parts.retain(|h| {
             if let Some(body) = bodies.get_mut(h.0) {

--- a/src/force_generator/force_generator.rs
+++ b/src/force_generator/force_generator.rs
@@ -4,19 +4,19 @@ use downcast_rs::Downcast;
 use generational_arena::Arena;
 use na::RealField;
 
-use crate::object::{BodySet, DefaultBodySet};
+use crate::object::{BodyHandle, BodySet, DefaultBodyHandle};
 use crate::solver::IntegrationParameters;
 
 /// Default force generator set based on an arena with generational indices.
-pub type DefaultForceGeneratorSet<N: RealField, Bodies: BodySet<N> = DefaultBodySet<N>> =
-    Arena<Box<dyn ForceGenerator<N, Bodies>>>;
+pub type DefaultForceGeneratorSet<N: RealField, Handle: BodyHandle = DefaultBodyHandle> =
+    Arena<Box<dyn ForceGenerator<N, Handle>>>;
 
 /// Trait implemented by sets of force generators.
 ///
 /// A set of bodies maps a force generator handle to a force generator instance.
-pub trait ForceGeneratorSet<N: RealField, Bodies: BodySet<N>> {
+pub trait ForceGeneratorSet<N: RealField, Handle: BodyHandle> {
     /// Type of a force generator stored in this set.
-    type ForceGenerator: ?Sized + ForceGenerator<N, Bodies>;
+    type ForceGenerator: ?Sized + ForceGenerator<N, Handle>;
     /// Type of a force generator handle identifying a force generator in this set.
     type Handle: Copy;
 
@@ -34,10 +34,10 @@ pub trait ForceGeneratorSet<N: RealField, Bodies: BodySet<N>> {
     fn foreach_mut(&mut self, f: impl FnMut(Self::Handle, &mut Self::ForceGenerator));
 }
 
-impl<N: RealField, Bodies: BodySet<N> + 'static> ForceGeneratorSet<N, Bodies>
-    for DefaultForceGeneratorSet<N, Bodies>
+impl<N: RealField, Handle: BodyHandle> ForceGeneratorSet<N, Handle>
+    for DefaultForceGeneratorSet<N, Handle>
 {
-    type ForceGenerator = dyn ForceGenerator<N, Bodies>;
+    type ForceGenerator = dyn ForceGenerator<N, Handle>;
     type Handle = DefaultForceGeneratorHandle;
 
     fn get(&self, handle: Self::Handle) -> Option<&Self::ForceGenerator> {
@@ -71,9 +71,13 @@ pub type DefaultForceGeneratorHandle = generational_arena::Index;
 /// A persistent force generator.
 ///
 /// A force generator applies a force to one or several bodies at each step of the simulation.
-pub trait ForceGenerator<N: RealField, Bodies: BodySet<N>>: Downcast + Send + Sync {
+pub trait ForceGenerator<N: RealField, Handle: BodyHandle>: Downcast + Send + Sync {
     /// Apply forces to some bodies.
-    fn apply(&mut self, parameters: &IntegrationParameters<N>, bodies: &mut Bodies);
+    fn apply(
+        &mut self,
+        parameters: &IntegrationParameters<N>,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
+    );
 }
 
-impl_downcast!(ForceGenerator<N, Bodies> where N: RealField, Bodies: BodySet<N>);
+impl_downcast!(ForceGenerator<N, Handle> where N: RealField, Handle: BodyHandle);

--- a/src/force_generator/spring.rs
+++ b/src/force_generator/spring.rs
@@ -2,7 +2,7 @@ use na::{RealField, Unit};
 
 use crate::force_generator::ForceGenerator;
 use crate::math::{ForceType, Point, Vector};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::IntegrationParameters;
 
 /// Generator of a force proportional to the distance separating two bodies.
@@ -53,10 +53,12 @@ impl<N: RealField, Handle: BodyHandle> Spring<N, Handle> {
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    ForceGenerator<N, Bodies> for Spring<N, Handle>
-{
-    fn apply(&mut self, _: &IntegrationParameters<N>, bodies: &mut Bodies) {
+impl<N: RealField, Handle: BodyHandle> ForceGenerator<N, Handle> for Spring<N, Handle> {
+    fn apply(
+        &mut self,
+        _: &IntegrationParameters<N>,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
+    ) {
         let body1 = try_ret!(bodies.get(self.b1.0));
         let body2 = try_ret!(bodies.get(self.b2.0));
         let part1 = try_ret!(body1.part(self.b1.1));

--- a/src/joint/ball_constraint.rs
+++ b/src/joint/ball_constraint.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use crate::joint::JointConstraint;
 use crate::math::{Point, Vector, DIM};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::helper;
 use crate::solver::{
     GenericNonlinearConstraint, IntegrationParameters, LinearConstraints,
@@ -63,9 +63,7 @@ impl<N: RealField, Handle: BodyHandle> BallConstraint<N, Handle> {
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    JointConstraint<N, Bodies> for BallConstraint<N, Handle>
-{
+impl<N: RealField, Handle: BodyHandle> JointConstraint<N, Handle> for BallConstraint<N, Handle> {
     fn is_broken(&self) -> bool {
         self.broken
     }
@@ -81,7 +79,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn velocity_constraints(
         &mut self,
         _: &IntegrationParameters<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
         ground_j_id: &mut usize,
         j_id: &mut usize,
@@ -148,10 +146,10 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    NonlinearConstraintGenerator<N, Bodies> for BallConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
+    for BallConstraint<N, Handle>
 {
-    fn num_position_constraints(&self, bodies: &Bodies) -> usize {
+    fn num_position_constraints(&self, bodies: &dyn BodySet<N, Handle = Handle>) -> usize {
         // FIXME: calling this at each iteration of the non-linear resolution is costly.
         if self.is_active(bodies) {
             1
@@ -164,7 +162,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
         &self,
         parameters: &IntegrationParameters<N>,
         _: usize,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         let body1 = bodies.get(self.b1.0)?;

--- a/src/joint/cartesian_constraint.rs
+++ b/src/joint/cartesian_constraint.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use crate::joint::JointConstraint;
 use crate::math::{AngularVector, Point, Rotation, ANGULAR_DIM};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::helper;
 use crate::solver::{
     GenericNonlinearConstraint, IntegrationParameters, LinearConstraints,
@@ -79,8 +79,8 @@ impl<N: RealField, Handle: BodyHandle> CartesianConstraint<N, Handle> {
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    JointConstraint<N, Bodies> for CartesianConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> JointConstraint<N, Handle>
+    for CartesianConstraint<N, Handle>
 {
     fn is_broken(&self) -> bool {
         self.broken
@@ -97,7 +97,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn velocity_constraints(
         &mut self,
         _: &IntegrationParameters<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
         ground_j_id: &mut usize,
         j_id: &mut usize,
@@ -160,10 +160,10 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    NonlinearConstraintGenerator<N, Bodies> for CartesianConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
+    for CartesianConstraint<N, Handle>
 {
-    fn num_position_constraints(&self, bodies: &Bodies) -> usize {
+    fn num_position_constraints(&self, bodies: &dyn BodySet<N, Handle = Handle>) -> usize {
         // FIXME: calling this at each iteration of the non-linear resolution is costly.
         if self.is_active(bodies) {
             1
@@ -176,7 +176,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
         &self,
         parameters: &IntegrationParameters<N>,
         _: usize,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         let body1 = bodies.get(self.b1.0)?;

--- a/src/joint/cartesian_joint.rs
+++ b/src/joint/cartesian_joint.rs
@@ -43,7 +43,6 @@ impl<N: RealField> Joint<N> for CartesianJoint<N> {
         _: &[N],
         _: &mut JacobianSliceMut<N>,
     ) {
-
     }
 
     fn jacobian_mul_coordinates(&self, vels: &[N]) -> Velocity<N> {

--- a/src/joint/cylindrical_constraint.rs
+++ b/src/joint/cylindrical_constraint.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use crate::joint::JointConstraint;
 use crate::math::{AngularVector, Point, Vector, DIM, SPATIAL_DIM};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::helper;
 use crate::solver::{
     GenericNonlinearConstraint, IntegrationParameters, LinearConstraints,
@@ -109,8 +109,8 @@ impl<N: RealField, Handle: BodyHandle> CylindricalConstraint<N, Handle> {
     // }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    JointConstraint<N, Bodies> for CylindricalConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> JointConstraint<N, Handle>
+    for CylindricalConstraint<N, Handle>
 {
     fn is_broken(&self) -> bool {
         self.broken
@@ -127,7 +127,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn velocity_constraints(
         &mut self,
         _: &IntegrationParameters<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
         ground_j_id: &mut usize,
         j_id: &mut usize,
@@ -237,10 +237,10 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    NonlinearConstraintGenerator<N, Bodies> for CylindricalConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
+    for CylindricalConstraint<N, Handle>
 {
-    fn num_position_constraints(&self, bodies: &Bodies) -> usize {
+    fn num_position_constraints(&self, bodies: &dyn BodySet<N, Handle = Handle>) -> usize {
         // FIXME: calling this at each iteration of the non-linear resolution is costly.
         if self.is_active(bodies) {
             2
@@ -253,7 +253,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
         &self,
         parameters: &IntegrationParameters<N>,
         i: usize,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         let body1 = bodies.get(self.b1.0)?;

--- a/src/joint/fixed_constraint.rs
+++ b/src/joint/fixed_constraint.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use crate::joint::JointConstraint;
 use crate::math::{AngularVector, Point, Rotation, Vector, DIM, SPATIAL_DIM};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::helper;
 use crate::solver::{
     GenericNonlinearConstraint, IntegrationParameters, LinearConstraints,
@@ -88,9 +88,7 @@ impl<N: RealField, Handle: BodyHandle> FixedConstraint<N, Handle> {
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    JointConstraint<N, Bodies> for FixedConstraint<N, Handle>
-{
+impl<N: RealField, Handle: BodyHandle> JointConstraint<N, Handle> for FixedConstraint<N, Handle> {
     fn is_broken(&self) -> bool {
         self.broken
     }
@@ -106,7 +104,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn velocity_constraints(
         &mut self,
         _: &IntegrationParameters<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
         ground_j_id: &mut usize,
         j_id: &mut usize,
@@ -201,10 +199,10 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    NonlinearConstraintGenerator<N, Bodies> for FixedConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
+    for FixedConstraint<N, Handle>
 {
-    fn num_position_constraints(&self, bodies: &Bodies) -> usize {
+    fn num_position_constraints(&self, bodies: &dyn BodySet<N, Handle = Handle>) -> usize {
         // FIXME: calling this at each iteration of the non-linear resolution is costly.
         if self.is_active(bodies) {
             2
@@ -217,7 +215,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
         &self,
         parameters: &IntegrationParameters<N>,
         i: usize,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         let body1 = bodies.get(self.b1.0)?;

--- a/src/joint/mouse_constraint.rs
+++ b/src/joint/mouse_constraint.rs
@@ -3,7 +3,7 @@ use na::{DVector, RealField, Unit};
 
 use crate::joint::JointConstraint;
 use crate::math::{Point, Vector, DIM};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::{
     helper, BilateralConstraint, BilateralGroundConstraint, ForceDirection, ImpulseLimits,
 };
@@ -53,9 +53,7 @@ impl<N: RealField, Handle: BodyHandle> MouseConstraint<N, Handle> {
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    JointConstraint<N, Bodies> for MouseConstraint<N, Handle>
-{
+impl<N: RealField, Handle: BodyHandle> JointConstraint<N, Handle> for MouseConstraint<N, Handle> {
     fn num_velocity_constraints(&self) -> usize {
         DIM
     }
@@ -67,7 +65,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn velocity_constraints(
         &mut self,
         parameters: &IntegrationParameters<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
         ground_j_id: &mut usize,
         j_id: &mut usize,
@@ -154,10 +152,10 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn cache_impulses(&mut self, _: &LinearConstraints<N, usize>, _: N) {}
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    NonlinearConstraintGenerator<N, Bodies> for MouseConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
+    for MouseConstraint<N, Handle>
 {
-    fn num_position_constraints(&self, _: &Bodies) -> usize {
+    fn num_position_constraints(&self, _: &dyn BodySet<N, Handle = Handle>) -> usize {
         0
     }
 
@@ -165,7 +163,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
         &self,
         _: &IntegrationParameters<N>,
         _: usize,
-        _: &mut Bodies,
+        _: &mut dyn BodySet<N, Handle = Handle>,
         _: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         None

--- a/src/joint/pin_slot_constraint.rs
+++ b/src/joint/pin_slot_constraint.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use crate::joint::JointConstraint;
 use crate::math::{AngularVector, Point, Vector, DIM, SPATIAL_DIM};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::helper;
 use crate::solver::{
     GenericNonlinearConstraint, IntegrationParameters, LinearConstraints,
@@ -117,9 +117,7 @@ impl<N: RealField, Handle: BodyHandle> PinSlotConstraint<N, Handle> {
     // }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    JointConstraint<N, Bodies> for PinSlotConstraint<N, Handle>
-{
+impl<N: RealField, Handle: BodyHandle> JointConstraint<N, Handle> for PinSlotConstraint<N, Handle> {
     fn is_broken(&self) -> bool {
         self.broken
     }
@@ -135,7 +133,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn velocity_constraints(
         &mut self,
         _: &IntegrationParameters<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
         ground_j_id: &mut usize,
         j_id: &mut usize,
@@ -246,10 +244,10 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    NonlinearConstraintGenerator<N, Bodies> for PinSlotConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
+    for PinSlotConstraint<N, Handle>
 {
-    fn num_position_constraints(&self, bodies: &Bodies) -> usize {
+    fn num_position_constraints(&self, bodies: &dyn BodySet<N, Handle = Handle>) -> usize {
         // FIXME: calling this at each iteration of the non-linear resolution is costly.
         if self.is_active(bodies) {
             2
@@ -262,7 +260,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
         &self,
         parameters: &IntegrationParameters<N>,
         i: usize,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         let body1 = bodies.get(self.b1.0)?;

--- a/src/joint/planar_constraint.rs
+++ b/src/joint/planar_constraint.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use crate::joint::JointConstraint;
 use crate::math::{AngularVector, Point};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::helper;
 use crate::solver::{
     GenericNonlinearConstraint, IntegrationParameters, LinearConstraints,
@@ -69,9 +69,7 @@ impl<N: RealField, Handle: BodyHandle> PlanarConstraint<N, Handle> {
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    JointConstraint<N, Bodies> for PlanarConstraint<N, Handle>
-{
+impl<N: RealField, Handle: BodyHandle> JointConstraint<N, Handle> for PlanarConstraint<N, Handle> {
     fn is_broken(&self) -> bool {
         self.broken
     }
@@ -87,7 +85,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn velocity_constraints(
         &mut self,
         _: &IntegrationParameters<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
         ground_j_id: &mut usize,
         j_id: &mut usize,
@@ -199,10 +197,10 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    NonlinearConstraintGenerator<N, Bodies> for PlanarConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
+    for PlanarConstraint<N, Handle>
 {
-    fn num_position_constraints(&self, bodies: &Bodies) -> usize {
+    fn num_position_constraints(&self, bodies: &dyn BodySet<N, Handle = Handle>) -> usize {
         // FIXME: calling this at each iteration of the non-linear resolution is costly.
         if self.is_active(bodies) {
             2
@@ -215,7 +213,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
         &self,
         parameters: &IntegrationParameters<N>,
         i: usize,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         let body1 = bodies.get(self.b1.0)?;

--- a/src/joint/prismatic_constraint.rs
+++ b/src/joint/prismatic_constraint.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use crate::joint::{unit_constraint, JointConstraint};
 use crate::math::{AngularVector, Point, Vector, DIM, SPATIAL_DIM};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::helper;
 use crate::solver::{
     GenericNonlinearConstraint, IntegrationParameters, LinearConstraints,
@@ -114,8 +114,8 @@ impl<N: RealField, Handle: BodyHandle> PrismaticConstraint<N, Handle> {
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    JointConstraint<N, Bodies> for PrismaticConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> JointConstraint<N, Handle>
+    for PrismaticConstraint<N, Handle>
 {
     fn is_broken(&self) -> bool {
         self.broken
@@ -132,7 +132,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn velocity_constraints(
         &mut self,
         _: &IntegrationParameters<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
         ground_j_id: &mut usize,
         j_id: &mut usize,
@@ -267,10 +267,10 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    NonlinearConstraintGenerator<N, Bodies> for PrismaticConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
+    for PrismaticConstraint<N, Handle>
 {
-    fn num_position_constraints(&self, bodies: &Bodies) -> usize {
+    fn num_position_constraints(&self, bodies: &dyn BodySet<N, Handle = Handle>) -> usize {
         // FIXME: calling this at each iteration of the non-linear resolution is costly.
         if self.is_active(bodies) {
             if self.min_offset.is_some() || self.max_offset.is_some() {
@@ -287,7 +287,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
         &self,
         parameters: &IntegrationParameters<N>,
         i: usize,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         let body1 = bodies.get(self.b1.0)?;

--- a/src/joint/rectangular_constraint.rs
+++ b/src/joint/rectangular_constraint.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use crate::joint::JointConstraint;
 use crate::math::{AngularVector, Point};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::helper;
 use crate::solver::{
     GenericNonlinearConstraint, IntegrationParameters, LinearConstraints,
@@ -65,8 +65,8 @@ impl<N: RealField, Handle: BodyHandle> RectangularConstraint<N, Handle> {
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    JointConstraint<N, Bodies> for RectangularConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> JointConstraint<N, Handle>
+    for RectangularConstraint<N, Handle>
 {
     fn is_broken(&self) -> bool {
         self.broken
@@ -83,7 +83,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn velocity_constraints(
         &mut self,
         _: &IntegrationParameters<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
         ground_j_id: &mut usize,
         j_id: &mut usize,
@@ -192,10 +192,10 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    NonlinearConstraintGenerator<N, Bodies> for RectangularConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
+    for RectangularConstraint<N, Handle>
 {
-    fn num_position_constraints(&self, bodies: &Bodies) -> usize {
+    fn num_position_constraints(&self, bodies: &dyn BodySet<N, Handle = Handle>) -> usize {
         // FIXME: calling this at each iteration of the non-linear resolution is costly.
         if self.is_active(bodies) {
             2
@@ -208,7 +208,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
         &self,
         parameters: &IntegrationParameters<N>,
         i: usize,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         let body1 = bodies.get(self.b1.0)?;

--- a/src/joint/revolute_constraint.rs
+++ b/src/joint/revolute_constraint.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 
 use crate::joint::JointConstraint;
 use crate::math::{AngularVector, Point, Vector, DIM, SPATIAL_DIM};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::helper;
 use crate::solver::{
     GenericNonlinearConstraint, IntegrationParameters, LinearConstraints,
@@ -160,8 +160,8 @@ impl<N: RealField, Handle: BodyHandle> RevoluteConstraint<N, Handle> {
     // }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    JointConstraint<N, Bodies> for RevoluteConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> JointConstraint<N, Handle>
+    for RevoluteConstraint<N, Handle>
 {
     fn is_broken(&self) -> bool {
         self.broken
@@ -178,7 +178,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn velocity_constraints(
         &mut self,
         _: &IntegrationParameters<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
         ground_j_id: &mut usize,
         j_id: &mut usize,
@@ -290,10 +290,10 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    NonlinearConstraintGenerator<N, Bodies> for RevoluteConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
+    for RevoluteConstraint<N, Handle>
 {
-    fn num_position_constraints(&self, bodies: &Bodies) -> usize {
+    fn num_position_constraints(&self, bodies: &dyn BodySet<N, Handle = Handle>) -> usize {
         // FIXME: calling this at each iteration of the non-linear resolution is costly.
         if self.is_active(bodies) {
             if DIM == 3 {
@@ -310,7 +310,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
         &self,
         parameters: &IntegrationParameters<N>,
         i: usize,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         let body1 = bodies.get(self.b1.0)?;

--- a/src/joint/universal_constraint.rs
+++ b/src/joint/universal_constraint.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use crate::joint::JointConstraint;
 use crate::math::{AngularVector, Point, Vector, DIM};
-use crate::object::{Body, BodyHandle, BodyPartHandle, BodySet};
+use crate::object::{BodyHandle, BodyPartHandle, BodySet};
 use crate::solver::helper;
 use crate::solver::{
     GenericNonlinearConstraint, IntegrationParameters, LinearConstraints,
@@ -70,8 +70,8 @@ impl<N: RealField, Handle: BodyHandle> UniversalConstraint<N, Handle> {
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    JointConstraint<N, Bodies> for UniversalConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> JointConstraint<N, Handle>
+    for UniversalConstraint<N, Handle>
 {
     fn is_broken(&self) -> bool {
         self.broken
@@ -88,7 +88,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     fn velocity_constraints(
         &mut self,
         _: &IntegrationParameters<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
         ground_j_id: &mut usize,
         j_id: &mut usize,
@@ -199,10 +199,10 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
     }
 }
 
-impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
-    NonlinearConstraintGenerator<N, Bodies> for UniversalConstraint<N, Handle>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
+    for UniversalConstraint<N, Handle>
 {
-    fn num_position_constraints(&self, bodies: &Bodies) -> usize {
+    fn num_position_constraints(&self, bodies: &dyn BodySet<N, Handle = Handle>) -> usize {
         // FIXME: calling this at each iteration of the non-linear resolution is costly.
         if self.is_active(bodies) {
             2
@@ -215,7 +215,7 @@ impl<N: RealField, Handle: BodyHandle, Bodies: BodySet<N, Handle = Handle>>
         &self,
         parameters: &IntegrationParameters<N>,
         i: usize,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         jacobians: &mut [N],
     ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         let body1 = bodies.get(self.b1.0)?;

--- a/src/object/mass_constraint_system.rs
+++ b/src/object/mass_constraint_system.rs
@@ -880,7 +880,8 @@ impl<N: RealField> BodyPart<N> for MassConstraintElement<N> {
     }
 
     fn position(&self) -> Isometry<N> {
-        Isometry::new(Vector::<N>::y() * na::convert::<_, N>(100.0f64), na::zero()) // XXX
+        // XXX
+        Isometry::new(Vector::<N>::y() * na::convert::<_, N>(100.0f64), na::zero())
     }
 
     fn velocity(&self) -> Velocity<N> {

--- a/src/object/mass_spring_system.rs
+++ b/src/object/mass_spring_system.rs
@@ -887,7 +887,8 @@ impl<N: RealField> BodyPart<N> for MassSpringElement<N> {
     }
 
     fn position(&self) -> Isometry<N> {
-        Isometry::new(Vector::<N>::y() * na::convert::<_, N>(100.0f64), na::zero()) // XXX
+        // XXX
+        Isometry::new(Vector::<N>::y() * na::convert::<_, N>(100.0f64), na::zero())
     }
 
     fn velocity(&self) -> Velocity<N> {

--- a/src/solver/contact_model.rs
+++ b/src/solver/contact_model.rs
@@ -6,37 +6,34 @@ use ncollide::query::ContactId;
 
 use crate::detection::ColliderContactManifold;
 use crate::material::MaterialsCoefficientsTable;
-use crate::object::{BodySet, ColliderHandle};
+use crate::object::{BodyHandle, BodySet, ColliderHandle};
 use crate::solver::{ConstraintSet, IntegrationParameters};
 
 /// The modeling of a contact.
-pub trait ContactModel<N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle>:
+pub trait ContactModel<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>:
     Downcast + Send + Sync
 {
     /// Maximum number of velocity constraint to be generated for each contact.
     fn num_velocity_constraints(
         &self,
-        manifold: &ColliderContactManifold<N, Bodies::Handle, CollHandle>,
+        manifold: &ColliderContactManifold<N, Handle, CollHandle>,
     ) -> usize;
     /// Generate all constraints for the given contact manifolds.
     fn constraints(
         &mut self,
         parameters: &IntegrationParameters<N>,
         material_coefficients: &MaterialsCoefficientsTable<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
-        manifolds: &[ColliderContactManifold<N, Bodies::Handle, CollHandle>],
+        manifolds: &[ColliderContactManifold<N, Handle, CollHandle>],
         ground_j_id: &mut usize,
         j_id: &mut usize,
         jacobians: &mut [N],
-        constraints: &mut ConstraintSet<N, Bodies::Handle, CollHandle, ContactId>,
+        constraints: &mut ConstraintSet<N, Handle, CollHandle, ContactId>,
     );
 
     /// Stores all the impulses found by the solver into a cache for warmstarting.
-    fn cache_impulses(
-        &mut self,
-        constraints: &ConstraintSet<N, Bodies::Handle, CollHandle, ContactId>,
-    );
+    fn cache_impulses(&mut self, constraints: &ConstraintSet<N, Handle, CollHandle, ContactId>);
 }
 
-impl_downcast!(ContactModel<N, Bodies, CollHandle> where N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle);
+impl_downcast!(ContactModel<N, Handle, CollHandle> where N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle);

--- a/src/solver/nonlinear_constraint.rs
+++ b/src/solver/nonlinear_constraint.rs
@@ -56,17 +56,17 @@ impl<N: RealField, Handle: BodyHandle> GenericNonlinearConstraint<N, Handle> {
 }
 
 /// Implemented by structures that generate non-linear constraints.
-pub trait NonlinearConstraintGenerator<N: RealField, Bodies: BodySet<N>> {
+pub trait NonlinearConstraintGenerator<N: RealField, Handle: BodyHandle> {
     /// Maximum of non-linear position constraint this generator needs to output.
-    fn num_position_constraints(&self, bodies: &Bodies) -> usize;
+    fn num_position_constraints(&self, bodies: &dyn BodySet<N, Handle = Handle>) -> usize;
     /// Generate the `i`-th position constraint of this generator.
     fn position_constraint(
         &self,
         parameters: &IntegrationParameters<N>,
         i: usize,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         jacobians: &mut [N],
-    ) -> Option<GenericNonlinearConstraint<N, Bodies::Handle>>;
+    ) -> Option<GenericNonlinearConstraint<N, Handle>>;
 }
 
 /// A non-linear position-based non-penetration constraint.
@@ -148,10 +148,10 @@ impl MultibodyJointLimitsNonlinearConstraintGenerator {
     }
 }
 
-impl<N: RealField, Bodies: BodySet<N>> NonlinearConstraintGenerator<N, Bodies>
+impl<N: RealField, Handle: BodyHandle> NonlinearConstraintGenerator<N, Handle>
     for MultibodyJointLimitsNonlinearConstraintGenerator
 {
-    fn num_position_constraints(&self, _: &Bodies) -> usize {
+    fn num_position_constraints(&self, _: &dyn BodySet<N, Handle = Handle>) -> usize {
         0
     }
 
@@ -159,9 +159,9 @@ impl<N: RealField, Bodies: BodySet<N>> NonlinearConstraintGenerator<N, Bodies>
         &self,
         _: &IntegrationParameters<N>,
         _: usize,
-        _: &mut Bodies,
+        _: &mut dyn BodySet<N, Handle = Handle>,
         _: &mut [N],
-    ) -> Option<GenericNonlinearConstraint<N, Bodies::Handle>> {
+    ) -> Option<GenericNonlinearConstraint<N, Handle>> {
         None
     }
 }

--- a/src/solver/signorini_model.rs
+++ b/src/solver/signorini_model.rs
@@ -150,11 +150,11 @@ impl<N: RealField> SignoriniModel<N> {
     }
 
     /// Builds non-linear position-based non-penetration constraints for the given contact manifold.
-    pub fn build_position_constraint<Bodies: BodySet<N>, CollHandle: ColliderHandle>(
-        bodies: &Bodies,
-        manifold: &ColliderContactManifold<N, Bodies::Handle, CollHandle>,
+    pub fn build_position_constraint<Handle: BodyHandle, CollHandle: ColliderHandle>(
+        bodies: &dyn BodySet<N, Handle = Handle>,
+        manifold: &ColliderContactManifold<N, Handle, CollHandle>,
         c: &TrackedContact<N>,
-        constraints: &mut ConstraintSet<N, Bodies::Handle, CollHandle, ContactId>,
+        constraints: &mut ConstraintSet<N, Handle, CollHandle, ContactId>,
     ) {
         let data1 = manifold.collider1;
         let data2 = manifold.collider2;
@@ -197,12 +197,12 @@ impl<N: RealField> SignoriniModel<N> {
     }
 }
 
-impl<N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle>
-    ContactModel<N, Bodies, CollHandle> for SignoriniModel<N>
+impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
+    ContactModel<N, Handle, CollHandle> for SignoriniModel<N>
 {
     fn num_velocity_constraints(
         &self,
-        c: &ColliderContactManifold<N, Bodies::Handle, CollHandle>,
+        c: &ColliderContactManifold<N, Handle, CollHandle>,
     ) -> usize {
         c.manifold.len()
     }
@@ -211,13 +211,13 @@ impl<N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle>
         &mut self,
         parameters: &IntegrationParameters<N>,
         coefficients: &MaterialsCoefficientsTable<N>,
-        bodies: &Bodies,
+        bodies: &dyn BodySet<N, Handle = Handle>,
         ext_vels: &DVector<N>,
-        manifolds: &[ColliderContactManifold<N, Bodies::Handle, CollHandle>],
+        manifolds: &[ColliderContactManifold<N, Handle, CollHandle>],
         ground_j_id: &mut usize,
         j_id: &mut usize,
         jacobians: &mut [N],
-        constraints: &mut ConstraintSet<N, Bodies::Handle, CollHandle, ContactId>,
+        constraints: &mut ConstraintSet<N, Handle, CollHandle, ContactId>,
     ) {
         let id_vel_ground = constraints.velocity.unilateral_ground.len();
         let id_vel = constraints.velocity.unilateral.len();
@@ -280,10 +280,7 @@ impl<N: RealField, Bodies: BodySet<N>, CollHandle: ColliderHandle>
         self.vel_rng = id_vel..constraints.velocity.unilateral.len();
     }
 
-    fn cache_impulses(
-        &mut self,
-        constraints: &ConstraintSet<N, Bodies::Handle, CollHandle, ContactId>,
-    ) {
+    fn cache_impulses(&mut self, constraints: &ConstraintSet<N, Handle, CollHandle, ContactId>) {
         let ground_contacts = &constraints.velocity.unilateral_ground[self.vel_ground_rng.clone()];
         let contacts = &constraints.velocity.unilateral[self.vel_rng.clone()];
 

--- a/src/solver/sor_prox.rs
+++ b/src/solver/sor_prox.rs
@@ -6,7 +6,7 @@ use ncollide::query::ContactId;
 // FIXME: could we just merge UnilateralConstraint and Bilateral constraint into a single structure
 // without performance impact due to clamping?
 use crate::math::{SpatialDim, SPATIAL_DIM};
-use crate::object::{Body, BodySet};
+use crate::object::{BodyHandle, BodySet};
 use crate::solver::{
     BilateralConstraint, BilateralGroundConstraint, ImpulseLimits, LinearConstraints,
     UnilateralConstraint, UnilateralGroundConstraint,
@@ -16,8 +16,8 @@ use crate::solver::{
 pub(crate) struct SORProx;
 
 impl SORProx {
-    fn warmstart_set<N: RealField, Bodies: BodySet<N>, Id>(
-        _bodies: &mut Bodies,
+    fn warmstart_set<N: RealField, Handle: BodyHandle, Id>(
+        _bodies: &mut dyn BodySet<N, Handle = Handle>,
         constraints: &mut LinearConstraints<N, Id>,
         jacobians: &[N],
         mj_lambda: &mut DVector<N>,
@@ -45,11 +45,11 @@ impl SORProx {
     }
 
     /// Solve the given set of constraints.
-    pub fn solve<N: RealField, Bodies: BodySet<N>>(
-        bodies: &mut Bodies,
+    pub fn solve<N: RealField, Handle: BodyHandle>(
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         contact_constraints: &mut LinearConstraints<N, ContactId>,
         joint_constraints: &mut LinearConstraints<N, usize>,
-        internal: &[Bodies::Handle],
+        internal: &[Handle],
         mj_lambda: &mut DVector<N>,
         jacobians: &[N],
         max_iter: usize,
@@ -79,8 +79,8 @@ impl SORProx {
         }
     }
 
-    fn step_unilateral<N: RealField, Bodies: BodySet<N>, Id>(
-        _bodies: &mut Bodies,
+    fn step_unilateral<N: RealField, Handle: BodyHandle, Id>(
+        _bodies: &mut dyn BodySet<N, Handle = Handle>,
         constraints: &mut LinearConstraints<N, Id>,
         jacobians: &[N],
         mj_lambda: &mut DVector<N>,
@@ -109,8 +109,8 @@ impl SORProx {
         }
     }
 
-    fn step_bilateral<N: RealField, Bodies: BodySet<N>, Id>(
-        _bodies: &mut Bodies,
+    fn step_bilateral<N: RealField, Handle: BodyHandle, Id>(
+        _bodies: &mut dyn BodySet<N, Handle = Handle>,
         constraints: &mut LinearConstraints<N, Id>,
         jacobians: &[N],
         mj_lambda: &mut DVector<N>,
@@ -156,11 +156,11 @@ impl SORProx {
         }
     }
 
-    fn step<N: RealField, Bodies: BodySet<N>>(
-        bodies: &mut Bodies,
+    fn step<N: RealField, Handle: BodyHandle>(
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         contact_constraints: &mut LinearConstraints<N, ContactId>,
         joint_constraints: &mut LinearConstraints<N, usize>,
-        internal: &[Bodies::Handle],
+        internal: &[Handle],
         jacobians: &[N],
         mj_lambda: &mut DVector<N>,
     ) {

--- a/src/world/geometrical_world.rs
+++ b/src/world/geometrical_world.rs
@@ -11,8 +11,8 @@ use ncollide::pipeline::{
 use ncollide::query::{ContactManifold, Proximity, Ray};
 
 use crate::object::{
-    Body, BodyHandle, BodySet, Collider, ColliderAnchor, ColliderHandle, ColliderSet,
-    DefaultBodyHandle, DefaultColliderHandle,
+    BodyHandle, BodySet, Collider, ColliderAnchor, ColliderHandle, ColliderSet, DefaultBodyHandle,
+    DefaultColliderHandle,
 };
 use crate::volumetric::Volumetric;
 
@@ -94,23 +94,20 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
     }
 
     /// Maintain the internal structures of the geometrical world by handling body removals and colliders insersion and removals.
-    pub fn maintain<Bodies, Colliders>(&mut self, bodies: &mut Bodies, colliders: &mut Colliders)
-    where
-        Bodies: BodySet<N, Handle = Handle>,
-        Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
-    {
+    pub fn maintain<Colliders: ColliderSet<N, Handle, Handle = CollHandle>>(
+        &mut self,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
+        colliders: &mut Colliders,
+    ) {
         self.handle_removals(bodies, colliders);
         self.handle_insertions(bodies, colliders);
     }
 
-    fn handle_insertions<Bodies, Colliders>(
+    fn handle_insertions<Colliders: ColliderSet<N, Handle, Handle = CollHandle>>(
         &mut self,
-        bodies: &mut Bodies,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
         colliders: &mut Colliders,
-    ) where
-        Bodies: BodySet<N, Handle = Handle>,
-        Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
-    {
+    ) {
         while let Some(handle) = colliders.pop_insertion_event() {
             if let Some(collider) = colliders.get_mut(handle) {
                 self.register_collider(handle, collider);
@@ -149,11 +146,11 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
         }
     }
 
-    fn handle_removals<Bodies, Colliders>(&mut self, bodies: &mut Bodies, colliders: &mut Colliders)
-    where
-        Bodies: BodySet<N, Handle = Handle>,
-        Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
-    {
+    fn handle_removals<Colliders: ColliderSet<N, Handle, Handle = CollHandle>>(
+        &mut self,
+        bodies: &mut dyn BodySet<N, Handle = Handle>,
+        colliders: &mut Colliders,
+    ) {
         let mut graph_id_remapping = HashMap::new();
 
         while let Some((removed_handle, mut removed)) = colliders.pop_removal_event() {
@@ -234,11 +231,11 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
     }
 
     /// Synchronize all colliders with their body parent and the underlying collision world.
-    pub fn sync_colliders<Bodies, Colliders>(&mut self, bodies: &Bodies, colliders: &mut Colliders)
-    where
-        Bodies: BodySet<N, Handle = Handle>,
-        Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
-    {
+    pub fn sync_colliders<Colliders: ColliderSet<N, Handle, Handle = CollHandle>>(
+        &mut self,
+        bodies: &dyn BodySet<N, Handle = Handle>,
+        colliders: &mut Colliders,
+    ) {
         colliders.foreach_mut(|_collider_id, collider| {
             let body = try_ret!(bodies.get(collider.body()));
 

--- a/src/world/mechanical_world.rs
+++ b/src/world/mechanical_world.rs
@@ -14,13 +14,13 @@ use crate::material::MaterialsCoefficientsTable;
 use crate::math::Vector;
 use crate::object::{
     Body, BodyHandle, BodyPartMotion, BodySet, BodyStatus, Collider, ColliderHandle, ColliderSet,
-    DefaultBodySet, DefaultColliderHandle,
+    DefaultBodyHandle, DefaultColliderHandle,
 };
 use crate::solver::{IntegrationParameters, MoreauJeanSolver, SignoriniCoulombPyramidModel};
 use crate::world::GeometricalWorld;
 
-/// The default mechanical world, that can be used with a `DefaultBodySet` and `DefaultColliderHandle`.
-pub type DefaultMechanicalWorld<N> = MechanicalWorld<N, DefaultBodySet<N>, DefaultColliderHandle>;
+/// The default mechanical world, that can be used with a `DefaultBodyHandle` and `DefaultColliderHandle`.
+pub type DefaultMechanicalWorld<N> = MechanicalWorld<N, DefaultBodyHandle, DefaultColliderHandle>;
 
 enum PredictedImpacts<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle> {
     Impacts(Vec<TOIEntry<N, Handle, CollHandle>>, HashMap<Handle, N>),


### PR DESCRIPTION
This commit prevents BodySet from polluting as a type parameter into all the core types required for physics stepping. Thanks to this, problems involved in dealing with these types in Specs usage are alleviated. However, this commit also removes the associated type of Body and always assumes dynamic dispatch on the Body type. This is an evolution of #226 that loosens future restrictions mentioned in that thread.