### PR TITLE
Fix warnings from `cargo test`

### DIFF
--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 rand       = { version = "0.7", features = [ "stdweb" ] }
+rand_distr = "0.2"
 num-traits = "0.2"
 Inflector  = "0.11"
 nalgebra   = "0.19"

--- a/examples3d/trimesh3.rs
+++ b/examples3d/trimesh3.rs
@@ -10,8 +10,8 @@ use nphysics3d::object::{
 use nphysics3d::world::{DefaultGeometricalWorld, DefaultMechanicalWorld};
 use nphysics_testbed3d::Testbed;
 
-use rand::distributions::{Distribution, Normal};
 use rand::thread_rng;
+use rand_distr::{Distribution, Normal};
 
 pub fn init_world(testbed: &mut Testbed) {
     /*
@@ -28,7 +28,7 @@ pub fn init_world(testbed: &mut Testbed) {
      * Use a fourier series to model ground height. This isn't an ideal terrain
      * model, but is a lot better than using uncorrelated random points.
      */
-    let distribution = Normal::new(0.0, 0.5);
+    let distribution = Normal::new(0.0, 0.5).unwrap();
 
     let make_fourier = || {
         let mut rng = thread_rng();

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -1087,7 +1087,8 @@ impl State for Testbed {
         if true {
             let counters = self.mechanical_world.counters;
 
-            let profile = format!(
+            #[allow(unused_mut)]
+            let mut profile = format!(
                 r#"Total: {:.2}ms
 Collision detection: {:.2}ms
 |_ Broad-phase: {:.2}ms

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -1087,7 +1087,7 @@ impl State for Testbed {
         if true {
             let counters = self.mechanical_world.counters;
 
-            let mut profile = format!(
+            let profile = format!(
                 r#"Total: {:.2}ms
 Collision detection: {:.2}ms
 |_ Broad-phase: {:.2}ms


### PR DESCRIPTION
Currently cloning `master` and running `cargo test` yields two warnings, this PR cleans those up.