### PR TITLE
Add set_up_axis method to testbed3d

### DIFF
--- a/src_testbed/engine.rs
+++ b/src_testbed/engine.rs
@@ -822,6 +822,11 @@ impl GraphicsManager {
     pub fn nodes_mut(&mut self) -> impl Iterator<Item = &mut Node> {
         self.b2sn.values_mut().flat_map(|val| val.iter_mut())
     }
+
+    #[cfg(feature = "dim3")]
+    pub fn set_up_axis(&mut self, up_axis: na::Vector3<f32>) {
+        self.camera.set_up_axis(up_axis);
+    }
 }
 
 impl Default for GraphicsManager {

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -377,6 +377,11 @@ impl Testbed {
         &mut self.graphics
     }
 
+    #[cfg(feature = "dim3")]
+    pub fn set_up_axis(&mut self, up_axis: Vector3<f32>) {
+        self.graphics.set_up_axis(up_axis);
+    }
+
     pub fn load_obj(path: &str) -> Vec<(Vec<Point3<f32>>, Vec<usize>)> {
         let path = Path::new(path);
         let empty = Path::new("_some_non_existant_folder"); // dont bother loading mtl files correctly


### PR DESCRIPTION
This exposes the `set_up_axis` method in Arc Ball camera of Kiss3d that
was added by sebcrozet/kiss3d#146 for the purpose of changing the
upward-pointing axis. Note that proper camera movement had not been
implemented in the referenced pull request.
