### PR TITLE
Make the testbed generic over RealField.

### DIFF
--- a/build/nphysics_testbed2d/Cargo.toml
+++ b/build/nphysics_testbed2d/Cargo.toml
@@ -24,6 +24,7 @@ parallel = [ "salva2d/parallel" ]
 
 
 [dependencies]
+alga       = "0.9"
 log        = { version = "0.4", optional = true }
 bitflags   = "1"
 num-traits = "0.2"

--- a/build/nphysics_testbed3d/Cargo.toml
+++ b/build/nphysics_testbed3d/Cargo.toml
@@ -22,6 +22,7 @@ fluids = [ "salva3d" ]
 parallel = [ "salva3d/parallel" ]
 
 [dependencies]
+alga       = "0.9"
 log        = { version = "0.4", optional = true }
 bitflags   = "1"
 num-traits = "0.2"

--- a/src_testbed/engine.rs
+++ b/src_testbed/engine.rs
@@ -1,14 +1,15 @@
+use alga::general::{SubsetOf, SupersetOf};
 #[cfg(feature = "dim3")]
 use kiss3d::camera::ArcBall as Camera;
 #[cfg(feature = "dim2")]
 use kiss3d::planar_camera::Sidescroll as Camera;
 use kiss3d::window::Window;
 use na;
-use na::Point3;
 #[cfg(feature = "dim2")]
 use na::Translation2 as Translation;
 #[cfg(feature = "dim3")]
 use na::Translation3 as Translation;
+use na::{Point3, RealField};
 use ncollide::shape::{self, Compound, Cuboid, Shape};
 
 use crate::objects::ball::Ball;
@@ -193,9 +194,9 @@ impl GraphicsManager {
         self.b2sn.remove(&body);
     }
 
-    pub fn remove_body_part_nodes(
+    pub fn remove_body_part_nodes<N: RealField>(
         &mut self,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         window: &mut Window,
         part: DefaultBodyPartHandle,
     ) -> DefaultBodyPartHandle {
@@ -312,7 +313,11 @@ impl GraphicsManager {
         color
     }
 
-    pub fn toggle_wireframe_mode(&mut self, colliders: &DefaultColliderSet<f32>, enabled: bool) {
+    pub fn toggle_wireframe_mode<N: RealField>(
+        &mut self,
+        colliders: &DefaultColliderSet<N>,
+        enabled: bool,
+    ) {
         for n in self.b2sn.values_mut().flat_map(|val| val.iter_mut()) {
             let force_wireframe = if let Some(collider) = colliders.get(n.collider()) {
                 collider.is_sensor()
@@ -384,11 +389,11 @@ impl GraphicsManager {
         self.f2sn.insert(handle, node);
     }
 
-    pub fn add(
+    pub fn add<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         id: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
     ) {
         let collider = colliders.get(id).unwrap();
 
@@ -403,11 +408,11 @@ impl GraphicsManager {
         self.add_with_color(window, id, colliders, color)
     }
 
-    pub fn add_with_color(
+    pub fn add_with_color<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         id: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         color: Point3<f32>,
     ) {
         let collider = colliders.get(id).unwrap();
@@ -447,65 +452,66 @@ impl GraphicsManager {
         }
     }
 
-    fn add_shape(
+    fn add_shape<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         object: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
-        shape: &dyn Shape<f32>,
+        shape: &dyn Shape<N>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
-        if let Some(s) = shape.as_shape::<shape::Plane<f32>>() {
+        if let Some(s) = shape.as_shape::<shape::Plane<N>>() {
             self.add_plane(window, object, colliders, s, color, out)
-        } else if let Some(s) = shape.as_shape::<shape::Ball<f32>>() {
+        } else if let Some(s) = shape.as_shape::<shape::Ball<N>>() {
             self.add_ball(window, object, colliders, delta, s, color, out)
-        } else if let Some(s) = shape.as_shape::<Cuboid<f32>>() {
+        } else if let Some(s) = shape.as_shape::<Cuboid<N>>() {
             self.add_box(window, object, colliders, delta, s, color, out)
-        } else if let Some(s) = shape.as_shape::<shape::Capsule<f32>>() {
+        } else if let Some(s) = shape.as_shape::<shape::Capsule<N>>() {
             self.add_capsule(window, object, colliders, delta, s, color, out)
-        } else if let Some(s) = shape.as_shape::<Compound<f32>>() {
+        } else if let Some(s) = shape.as_shape::<Compound<N>>() {
             for &(t, ref s) in s.shapes().iter() {
+                let t: Isometry<f32> = na::convert(t);
                 self.add_shape(window, object, colliders, delta * t, s.as_ref(), color, out)
             }
         }
 
         #[cfg(feature = "dim2")]
         {
-            if let Some(s) = shape.as_shape::<ConvexPolygon<f32>>() {
+            if let Some(s) = shape.as_shape::<ConvexPolygon<N>>() {
                 self.add_convex(window, object, colliders, delta, s, color, out)
-            } else if let Some(s) = shape.as_shape::<shape::Polyline<f32>>() {
+            } else if let Some(s) = shape.as_shape::<shape::Polyline<N>>() {
                 self.add_polyline(window, object, colliders, delta, s, color, out);
-            } else if let Some(s) = shape.as_shape::<shape::HeightField<f32>>() {
+            } else if let Some(s) = shape.as_shape::<shape::HeightField<N>>() {
                 self.add_heightfield(window, object, colliders, delta, s, color, out);
             }
         }
 
         #[cfg(feature = "dim3")]
         {
-            if let Some(s) = shape.as_shape::<ConvexHull<f32>>() {
+            if let Some(s) = shape.as_shape::<ConvexHull<N>>() {
                 self.add_convex(window, object, colliders, delta, s, color, out)
-            } else if let Some(s) = shape.as_shape::<TriMesh<f32>>() {
+            } else if let Some(s) = shape.as_shape::<TriMesh<N>>() {
                 self.add_mesh(window, object, colliders, delta, s, color, out);
-            } else if let Some(s) = shape.as_shape::<shape::HeightField<f32>>() {
+            } else if let Some(s) = shape.as_shape::<shape::HeightField<N>>() {
                 self.add_heightfield(window, object, colliders, delta, s, color, out);
             }
         }
     }
 
-    fn add_plane(
+    fn add_plane<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         object: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
-        shape: &shape::Plane<f32>,
+        colliders: &DefaultColliderSet<N>,
+        shape: &shape::Plane<N>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
         let pos = colliders.get(object).unwrap().position();
-        let position = Point::from(pos.translation.vector);
-        let normal = pos * shape.normal();
+        let position = na::convert(Point::from(pos.translation.vector));
+        let normal = na::convert(pos * shape.normal().into_inner());
 
         out.push(Node::Plane(Plane::new(
             object, colliders, &position, &normal, color, window,
@@ -513,17 +519,17 @@ impl GraphicsManager {
     }
 
     #[cfg(feature = "dim2")]
-    fn add_polyline(
+    fn add_polyline<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         object: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
-        shape: &shape::Polyline<f32>,
+        shape: &shape::Polyline<N>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
-        let vertices = shape.points().to_vec();
+        let vertices = shape.points().iter().map(|p| na::convert(*p)).collect();
         let indices = shape.edges().iter().map(|e| e.indices).collect();
 
         out.push(Node::Polyline(Polyline::new(
@@ -532,42 +538,42 @@ impl GraphicsManager {
     }
 
     #[cfg(feature = "dim3")]
-    fn add_mesh(
+    fn add_mesh<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         object: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
-        shape: &TriMesh<f32>,
+        shape: &TriMesh<N>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
-        let points = shape.points();
-        let faces = shape.faces();
-
-        let is = faces
+        let is = shape
+            .faces()
             .iter()
-            .map(|f| Point3::new(f.indices.x as u32, f.indices.y as u32, f.indices.z as u32))
+            .map(|f| {
+                na::convert(Point3::new(
+                    f.indices.x as u32,
+                    f.indices.y as u32,
+                    f.indices.z as u32,
+                ))
+            })
             .collect();
 
+        let points = shape.points().iter().map(|&p| na::convert(p)).collect();
+
         out.push(Node::Mesh(Mesh::new(
-            object,
-            colliders,
-            delta,
-            points.to_vec(),
-            is,
-            color,
-            window,
+            object, colliders, delta, points, is, color, window,
         )))
     }
 
-    fn add_heightfield(
+    fn add_heightfield<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         object: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
-        heightfield: &shape::HeightField<f32>,
+        heightfield: &shape::HeightField<N>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
@@ -581,13 +587,13 @@ impl GraphicsManager {
         )))
     }
 
-    fn add_capsule(
+    fn add_capsule<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         object: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
-        shape: &shape::Capsule<f32>,
+        shape: &shape::Capsule<N>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
@@ -596,20 +602,20 @@ impl GraphicsManager {
             object,
             colliders,
             delta,
-            shape.radius() + margin,
-            shape.height(),
+            na::convert(shape.radius() + margin),
+            na::convert(shape.height()),
             color,
             window,
         )))
     }
 
-    fn add_ball(
+    fn add_ball<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         object: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
-        shape: &shape::Ball<f32>,
+        shape: &shape::Ball<N>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
@@ -618,19 +624,19 @@ impl GraphicsManager {
             object,
             colliders,
             delta,
-            shape.radius() + margin,
+            na::convert(shape.radius() + margin),
             color,
             window,
         )))
     }
 
-    fn add_box(
+    fn add_box<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         object: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
-        shape: &Cuboid<f32>,
+        shape: &Cuboid<N>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
@@ -640,47 +646,43 @@ impl GraphicsManager {
             object,
             colliders,
             delta,
-            shape.half_extents() + Vector::repeat(margin),
+            na::convert(shape.half_extents() + Vector::repeat(margin)),
             color,
             window,
         )))
     }
 
     #[cfg(feature = "dim2")]
-    fn add_convex(
+    fn add_convex<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         object: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
-        shape: &ConvexPolygon<f32>,
+        shape: &ConvexPolygon<N>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
-        let points = shape.points();
+        let points: Vec<_> = shape.points().iter().map(|p| na::convert(*p)).collect();
 
         out.push(Node::Convex(Convex::new(
-            object,
-            colliders,
-            delta,
-            points.to_vec(),
-            color,
-            window,
+            object, colliders, delta, points, color, window,
         )))
     }
 
     #[cfg(feature = "dim3")]
-    fn add_convex(
+    fn add_convex<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         object: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
-        shape: &ConvexHull<f32>,
+        shape: &ConvexHull<N>,
         color: Point3<f32>,
         out: &mut Vec<Node>,
     ) {
-        let mut chull = transformation::convex_hull(shape.points());
+        let points: Vec<_> = shape.points().iter().map(|p| na::convert(*p)).collect();
+        let mut chull = transformation::convex_hull(&points);
         chull.replicate_vertices();
         chull.recompute_normals();
 
@@ -689,10 +691,10 @@ impl GraphicsManager {
         )))
     }
 
-    pub fn show_aabbs(
+    pub fn show_aabbs<N: RealField>(
         &mut self,
-        _geometrical_world: &DefaultGeometricalWorld<f32>,
-        colliders: &DefaultColliderSet<f32>,
+        _geometrical_world: &DefaultGeometricalWorld<N>,
+        colliders: &DefaultColliderSet<N>,
         window: &mut Window,
     ) {
         for (_, ns) in self.b2sn.iter() {
@@ -741,10 +743,10 @@ impl GraphicsManager {
         }
     }
 
-    pub fn draw(
+    pub fn draw<N: RealField + SubsetOf<f32> + SupersetOf<f32>>(
         &mut self,
-        geometrical_world: &DefaultGeometricalWorld<f32>,
-        colliders: &DefaultColliderSet<f32>,
+        geometrical_world: &DefaultGeometricalWorld<N>,
+        colliders: &DefaultColliderSet<N>,
         window: &mut Window,
     ) {
         //        use crate::kiss3d::camera::Camera;
@@ -770,25 +772,33 @@ impl GraphicsManager {
                     .map(|p| p.0);
 
                 if let Some(aabb) = aabb {
-                    let w = aabb.half_extents() * 2.0;
+                    let mut w = aabb.half_extents();
+                    w += w;
 
-                    node.set_local_translation(Translation::from(aabb.center().coords));
+                    let center: Vector<_> = na::convert(aabb.center().coords);
+                    node.set_local_translation(Translation::from(center));
 
                     #[cfg(feature = "dim2")]
-                    node.set_local_scale(w.x, w.y);
+                    node.set_local_scale(na::convert(w.x), na::convert(w.y));
                     #[cfg(feature = "dim3")]
-                    node.set_local_scale(w.x, w.y, w.z);
+                    node.set_local_scale(na::convert(w.x), na::convert(w.y), na::convert(w.z));
                 }
             }
         }
 
-        for ray in &self.rays {
+        for &Ray { origin, dir } in &self.rays {
+            let ray = Ray {
+                origin: na::convert(origin),
+                dir: na::convert(dir),
+            };
             let groups = CollisionGroups::new();
             let inter =
-                geometrical_world.interferences_with_ray(colliders, ray, std::f32::MAX, &groups);
-            let hit = inter.fold(1000.0, |t, (_, _, hit)| hit.toi.min(t));
-            let p1 = ray.origin;
-            let p2 = ray.origin + ray.dir * hit;
+                geometrical_world.interferences_with_ray(colliders, &ray, N::max_value(), &groups);
+            let hit = inter.fold(1000.0f32, |t, (_, _, hit)| {
+                na::convert::<N, f32>(hit.toi).min(t)
+            });
+            let p1 = origin;
+            let p2 = p1 + dir * hit;
             window.draw_graphics_line(&p1, &p2, &Point3::new(1.0, 0.0, 0.0));
         }
     }

--- a/src_testbed/engine.rs
+++ b/src_testbed/engine.rs
@@ -347,12 +347,12 @@ impl GraphicsManager {
     }
 
     #[cfg(feature = "fluids")]
-    pub fn add_fluid(
+    pub fn add_fluid<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         handle: FluidHandle,
-        fluid: &Fluid<f32>,
-        particle_radius: f32,
+        fluid: &Fluid<N>,
+        particle_radius: N,
     ) {
         let rand = &mut self.rand;
         let color = *self
@@ -364,28 +364,38 @@ impl GraphicsManager {
     }
 
     #[cfg(feature = "fluids")]
-    pub fn add_boundary(
+    pub fn add_boundary<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         handle: BoundaryHandle,
-        boundary: &Boundary<f32>,
-        particle_radius: f32,
+        boundary: &Boundary<N>,
+        particle_radius: N,
     ) {
         let color = self.ground_color;
-        let node = FluidNode::new(particle_radius, &boundary.positions, color, window);
+        let node = FluidNode::new(
+            na::convert(particle_radius),
+            &boundary.positions,
+            color,
+            window,
+        );
         self.boundary2sn.insert(handle, node);
     }
 
     #[cfg(feature = "fluids")]
-    pub fn add_fluid_with_color(
+    pub fn add_fluid_with_color<N: RealField + SubsetOf<f32>>(
         &mut self,
         window: &mut Window,
         handle: FluidHandle,
-        fluid: &Fluid<f32>,
-        particle_radius: f32,
+        fluid: &Fluid<N>,
+        particle_radius: N,
         color: Point3<f32>,
     ) {
-        let node = FluidNode::new(particle_radius, &fluid.positions, color, window);
+        let node = FluidNode::new(
+            na::convert(particle_radius),
+            &fluid.positions,
+            color,
+            window,
+        );
         self.f2sn.insert(handle, node);
     }
 
@@ -727,7 +737,7 @@ impl GraphicsManager {
     }
 
     #[cfg(feature = "fluids")]
-    pub fn draw_fluids(&mut self, liquid_world: &LiquidWorld<f32>) {
+    pub fn draw_fluids<N: RealField + SubsetOf<f32>>(&mut self, liquid_world: &LiquidWorld<N>) {
         for (i, fluid) in liquid_world.fluids().iter() {
             if let Some(node) = self.f2sn.get_mut(&i) {
                 node.update_with_fluid(fluid, self.fluid_rendering_mode)

--- a/src_testbed/objects/ball.rs
+++ b/src_testbed/objects/ball.rs
@@ -1,6 +1,7 @@
 use crate::objects::node::{self, GraphicsNode};
+use alga::general::SubsetOf;
 use kiss3d::window::Window;
-use na::Point3;
+use na::{Point3, RealField};
 use nphysics::math::Isometry;
 use nphysics::object::{DefaultColliderHandle, DefaultColliderSet};
 
@@ -13,9 +14,9 @@ pub struct Ball {
 }
 
 impl Ball {
-    pub fn new(
+    pub fn new<N: RealField + SubsetOf<f32>>(
         collider: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
         radius: f32,
         color: Point3<f32>,
@@ -44,10 +45,11 @@ impl Ball {
             res.gfx.set_lines_width(1.0);
         }
 
+        let pos: Isometry<f32> = na::convert(*colliders.get(collider).unwrap().position());
+
         // res.gfx.set_texture_from_file(&Path::new("media/kitten.png"), "kitten");
         res.gfx.set_color(color.x, color.y, color.z);
-        res.gfx
-            .set_local_transformation(colliders.get(collider).unwrap().position() * res.delta);
+        res.gfx.set_local_transformation(pos * res.delta);
         res.update(colliders);
 
         res
@@ -67,7 +69,7 @@ impl Ball {
         self.base_color = color;
     }
 
-    pub fn update(&mut self, colliders: &DefaultColliderSet<f32>) {
+    pub fn update<N: RealField + SubsetOf<f32>>(&mut self, colliders: &DefaultColliderSet<N>) {
         node::update_scene_node(
             &mut self.gfx,
             colliders,

--- a/src_testbed/objects/box_node.rs
+++ b/src_testbed/objects/box_node.rs
@@ -1,6 +1,7 @@
 use crate::objects::node::{self, GraphicsNode};
+use alga::general::SubsetOf;
 use kiss3d::window;
-use na::Point3;
+use na::{Point3, RealField};
 use nphysics::math::{Isometry, Vector};
 use nphysics::object::{DefaultColliderHandle, DefaultColliderSet};
 
@@ -13,9 +14,9 @@ pub struct Box {
 }
 
 impl Box {
-    pub fn new(
+    pub fn new<N: RealField + SubsetOf<f32>>(
         collider: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
         half_extents: Vector<f32>,
         color: Point3<f32>,
@@ -45,9 +46,10 @@ impl Box {
             res.gfx.set_lines_width(1.0);
         }
 
+        let pos: Isometry<f32> = na::convert(*colliders.get(collider).unwrap().position());
+
         res.gfx.set_color(color.x, color.y, color.z);
-        res.gfx
-            .set_local_transformation(colliders.get(collider).unwrap().position() * res.delta);
+        res.gfx.set_local_transformation(pos * res.delta);
         res.update(colliders);
 
         res
@@ -67,7 +69,7 @@ impl Box {
         self.base_color = color;
     }
 
-    pub fn update(&mut self, colliders: &DefaultColliderSet<f32>) {
+    pub fn update<N: RealField + SubsetOf<f32>>(&mut self, colliders: &DefaultColliderSet<N>) {
         node::update_scene_node(
             &mut self.gfx,
             colliders,

--- a/src_testbed/objects/capsule.rs
+++ b/src_testbed/objects/capsule.rs
@@ -1,6 +1,7 @@
 use crate::objects::node::{self, GraphicsNode};
+use alga::general::SubsetOf;
 use kiss3d::window;
-use na::Point3;
+use na::{Point3, RealField};
 use nphysics::math::Isometry;
 use nphysics::object::{DefaultColliderHandle, DefaultColliderSet};
 
@@ -13,9 +14,9 @@ pub struct Capsule {
 }
 
 impl Capsule {
-    pub fn new(
+    pub fn new<N: RealField + SubsetOf<f32>>(
         collider: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
         r: f32,
         h: f32,
@@ -35,6 +36,8 @@ impl Capsule {
             collider,
         };
 
+        let pos: Isometry<f32> = na::convert(*colliders.get(collider).unwrap().position());
+
         if colliders
             .get(collider)
             .unwrap()
@@ -45,8 +48,7 @@ impl Capsule {
             res.gfx.set_lines_width(1.0);
         }
         res.gfx.set_color(color.x, color.y, color.z);
-        res.gfx
-            .set_local_transformation(colliders.get(collider).unwrap().position() * res.delta);
+        res.gfx.set_local_transformation(pos * res.delta);
         res.update(colliders);
 
         res
@@ -60,7 +62,7 @@ impl Capsule {
         self.color = self.base_color;
     }
 
-    pub fn update(&mut self, colliders: &DefaultColliderSet<f32>) {
+    pub fn update<N: RealField + SubsetOf<f32>>(&mut self, colliders: &DefaultColliderSet<N>) {
         node::update_scene_node(
             &mut self.gfx,
             colliders,

--- a/src_testbed/objects/convex.rs
+++ b/src_testbed/objects/convex.rs
@@ -1,6 +1,7 @@
 use crate::objects::node::{self, GraphicsNode};
+use alga::general::SubsetOf;
 use kiss3d::window::Window;
-use na::Point3;
+use na::{Point3, RealField};
 #[cfg(feature = "dim3")]
 use ncollide::procedural::TriMesh;
 #[cfg(feature = "dim2")]
@@ -18,9 +19,9 @@ pub struct Convex {
 
 impl Convex {
     #[cfg(feature = "dim2")]
-    pub fn new(
+    pub fn new<N: RealField + SubsetOf<f32>>(
         collider: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
         vertices: Vec<Point<f32>>,
         color: Point3<f32>,
@@ -44,18 +45,19 @@ impl Convex {
             res.gfx.set_lines_width(1.0);
         }
 
+        let pos: Isometry<f32> = na::convert(*colliders.get(collider).unwrap().position());
+
         res.gfx.set_color(color.x, color.y, color.z);
-        res.gfx
-            .set_local_transformation(colliders.get(collider).unwrap().position() * res.delta);
+        res.gfx.set_local_transformation(pos * res.delta);
         res.update(colliders);
 
         res
     }
 
     #[cfg(feature = "dim3")]
-    pub fn new(
+    pub fn new<N: RealField + SubsetOf<f32>>(
         collider: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         delta: Isometry<f32>,
         convex: &TriMesh<f32>,
         color: Point3<f32>,
@@ -79,9 +81,10 @@ impl Convex {
             res.gfx.set_lines_width(1.0);
         }
 
+        let pos: Isometry<f32> = na::convert(*colliders.get(collider).unwrap().position());
+
         res.gfx.set_color(color.x, color.y, color.z);
-        res.gfx
-            .set_local_transformation(colliders.get(collider).unwrap().position() * res.delta);
+        res.gfx.set_local_transformation(pos * res.delta);
         res.update(colliders);
 
         res
@@ -101,7 +104,7 @@ impl Convex {
         self.base_color = color;
     }
 
-    pub fn update(&mut self, colliders: &DefaultColliderSet<f32>) {
+    pub fn update<N: RealField + SubsetOf<f32>>(&mut self, colliders: &DefaultColliderSet<N>) {
         node::update_scene_node(
             &mut self.gfx,
             colliders,

--- a/src_testbed/objects/fluid.rs
+++ b/src_testbed/objects/fluid.rs
@@ -1,4 +1,5 @@
 use crate::objects::node::GraphicsNode;
+use alga::general::SubsetOf;
 use kiss3d::window::Window;
 use na::{Point3, RealField, Vector3};
 use nphysics::math::{Point, Vector};
@@ -19,9 +20,9 @@ pub struct Fluid {
 }
 
 impl Fluid {
-    pub fn new(
+    pub fn new<N: RealField + SubsetOf<f32>>(
         radius: f32,
-        centers: &[Point<f32>],
+        centers: &[Point<N>],
         color: Point3<f32>,
         window: &mut Window,
     ) -> Fluid {
@@ -37,7 +38,8 @@ impl Fluid {
             let mut ball_gfx = gfx.add_circle(radius);
             #[cfg(feature = "dim3")]
             let mut ball_gfx = gfx.add_sphere(radius);
-            ball_gfx.set_local_translation(c.coords.into());
+            let c: Vector<f32> = na::convert(c.coords);
+            ball_gfx.set_local_translation(c.into());
             balls_gfx.push(ball_gfx);
         }
 
@@ -67,10 +69,10 @@ impl Fluid {
         self.base_color = color;
     }
 
-    fn update(
+    fn update<N: RealField + SubsetOf<f32>>(
         &mut self,
-        centers: &[Point<f32>],
-        velocities: &[Vector<f32>],
+        centers: &[Point<N>],
+        velocities: &[Vector<N>],
         mode: FluidRenderingMode,
     ) {
         if centers.len() > self.balls_gfx.len() {
@@ -89,14 +91,15 @@ impl Fluid {
 
         for (i, (pt, ball)) in centers.iter().zip(self.balls_gfx.iter_mut()).enumerate() {
             ball.set_visible(true);
-            ball.set_local_translation(pt.coords.into());
+            let c: Vector<f32> = na::convert(pt.coords);
+            ball.set_local_translation(c.into());
 
             let color = match mode {
                 FluidRenderingMode::StaticColor => self.base_color,
                 FluidRenderingMode::VelocityColor { min, max } => {
                     let start = self.base_color.coords;
                     let end = Vector3::new(1.0, 0.0, 0.0);
-                    let vel = velocities[i];
+                    let vel: Vector<f32> = na::convert(velocities[i]);
                     let t = (vel.norm() - min) / (max - min);
                     start.lerp(&end, na::clamp(t, 0.0, 1.0)).into()
                 }
@@ -106,13 +109,13 @@ impl Fluid {
         }
     }
 
-    pub fn update_with_boundary(&mut self, boundary: &Boundary<N>) {
+    pub fn update_with_boundary<N: RealField + SubsetOf<f32>>(&mut self, boundary: &Boundary<N>) {
         self.update(&boundary.positions, &[], FluidRenderingMode::StaticColor)
     }
 
-    pub fn update_with_fluid(
+    pub fn update_with_fluid<N: RealField + SubsetOf<f32>>(
         &mut self,
-        fluid: &SalvaFluid<f32>,
+        fluid: &SalvaFluid<N>,
         rendering_mode: FluidRenderingMode,
     ) {
         self.update(&fluid.positions, &fluid.velocities, rendering_mode)

--- a/src_testbed/objects/fluid.rs
+++ b/src_testbed/objects/fluid.rs
@@ -1,6 +1,6 @@
 use crate::objects::node::GraphicsNode;
 use kiss3d::window::Window;
-use na::{Point3, Vector3};
+use na::{Point3, RealField, Vector3};
 use nphysics::math::{Point, Vector};
 use salva::object::{Boundary, Fluid as SalvaFluid};
 
@@ -106,7 +106,7 @@ impl Fluid {
         }
     }
 
-    pub fn update_with_boundary(&mut self, boundary: &Boundary<f32>) {
+    pub fn update_with_boundary(&mut self, boundary: &Boundary<N>) {
         self.update(&boundary.positions, &[], FluidRenderingMode::StaticColor)
     }
 

--- a/src_testbed/objects/node.rs
+++ b/src_testbed/objects/node.rs
@@ -8,8 +8,9 @@ use crate::objects::mesh::Mesh;
 use crate::objects::plane::Plane;
 #[cfg(feature = "dim2")]
 use crate::objects::polyline::Polyline;
+use alga::general::SubsetOf;
 use kiss3d::window::Window;
-use na::Point3;
+use na::{Point3, RealField};
 use nphysics::math::Isometry;
 use nphysics::object::{DefaultColliderHandle, DefaultColliderSet};
 
@@ -62,7 +63,7 @@ impl Node {
         }
     }
 
-    pub fn update(&mut self, colliders: &DefaultColliderSet<f32>) {
+    pub fn update<N: RealField + SubsetOf<f32>>(&mut self, colliders: &DefaultColliderSet<N>) {
         match *self {
             Node::Plane(ref mut n) => n.update(colliders),
             Node::Ball(ref mut n) => n.update(colliders),
@@ -154,15 +155,16 @@ impl Node {
     }
 }
 
-pub fn update_scene_node(
+pub fn update_scene_node<N: RealField + SubsetOf<f32>>(
     node: &mut GraphicsNode,
-    colliders: &DefaultColliderSet<f32>,
+    colliders: &DefaultColliderSet<N>,
     coll: DefaultColliderHandle,
     color: &Point3<f32>,
     delta: &Isometry<f32>,
 ) {
     if let Some(co) = colliders.get(coll) {
-        node.set_local_transformation(co.position() * delta);
+        let pos: Isometry<f32> = na::convert(*co.position());
+        node.set_local_transformation(pos * delta);
         node.set_color(color.x, color.y, color.z);
     } else {
         node.set_color(color.x * 0.25, color.y * 0.25, color.z * 0.25);

--- a/src_testbed/objects/plane.rs
+++ b/src_testbed/objects/plane.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "dim3")]
 use crate::objects::node::GraphicsNode;
 use kiss3d::window::Window;
-use na::Point3;
 #[cfg(feature = "dim3")]
 use na::Vector3;
+use na::{Point3, RealField};
 #[cfg(feature = "dim2")]
 use nphysics::math::{Point, Vector};
 use nphysics::object::{DefaultColliderHandle, DefaultColliderSet};
@@ -27,9 +27,9 @@ pub struct Plane {
 
 impl Plane {
     #[cfg(feature = "dim2")]
-    pub fn new(
+    pub fn new<N: RealField>(
         collider: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         position: &Point<f32>,
         normal: &Vector<f32>,
         color: Point3<f32>,
@@ -48,9 +48,9 @@ impl Plane {
     }
 
     #[cfg(feature = "dim3")]
-    pub fn new(
+    pub fn new<N: RealField>(
         collider: DefaultColliderHandle,
-        colliders: &DefaultColliderSet<f32>,
+        colliders: &DefaultColliderSet<N>,
         world_pos: &Point3<f32>,
         world_normal: &Vector3<f32>,
         color: Point3<f32>,
@@ -91,7 +91,7 @@ impl Plane {
 
     pub fn unselect(&mut self) {}
 
-    pub fn update(&mut self, _: &DefaultColliderSet<f32>) {
+    pub fn update<N: RealField>(&mut self, _: &DefaultColliderSet<N>) {
         // FIXME: atm we assume the plane does not move
     }
 

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -117,15 +117,15 @@ pub struct TestbedState<N: RealField> {
 }
 
 #[cfg(feature = "fluids")]
-struct FluidsState {
-    world: LiquidWorld<f32>,
-    coupling: ColliderCouplingSet<f32, DefaultBodyHandle>,
+struct FluidsState<N: RealField> {
+    world: LiquidWorld<N>,
+    coupling: ColliderCouplingSet<N, DefaultBodyHandle>,
 }
 
 pub struct Testbed<N: RealField = f32> {
     builders: Vec<(&'static str, fn(&mut Testbed<N>))>,
     #[cfg(feature = "fluids")]
-    fluids: Option<FluidsState>,
+    fluids: Option<FluidsState<N>>,
     mechanical_world: DefaultMechanicalWorld<N>,
     geometrical_world: DefaultGeometricalWorld<N>,
     bodies: DefaultBodySet<N>,
@@ -138,7 +138,7 @@ pub struct Testbed<N: RealField = f32> {
     camera_locked: bool, // Used so that the camera can remain the same before and after we change backend or press the restart button.
     callbacks: Callbacks<N>,
     #[cfg(feature = "fluids")]
-    callbacks_fluids: CallbacksFluids,
+    callbacks_fluids: CallbacksFluids<N>,
     time: N,
     hide_counters: bool,
     persistant_contacts: HashMap<ContactId, bool>,
@@ -482,14 +482,14 @@ impl<N: RealField + SupersetOf<f32> + SubsetOf<f32>> Testbed<N> {
     #[cfg(feature = "fluids")]
     pub fn add_callback_with_fluids<
         F: FnMut(
-                &mut LiquidWorld<f32>,
-                &mut ColliderCouplingSet<f32, DefaultBodyHandle>,
-                &mut DefaultMechanicalWorld<f32>,
-                &mut DefaultGeometricalWorld<f32>,
-                &mut DefaultBodySet<f32>,
-                &mut DefaultColliderSet<f32>,
+                &mut LiquidWorld<N>,
+                &mut ColliderCouplingSet<N, DefaultBodyHandle>,
+                &mut DefaultMechanicalWorld<N>,
+                &mut DefaultGeometricalWorld<N>,
+                &mut DefaultBodySet<N>,
+                &mut DefaultColliderSet<N>,
                 &mut GraphicsManager,
-                f32,
+                N,
             ) + 'static,
     >(
         &mut self,


### PR DESCRIPTION
This leaves all the graphics objects in `f32`, but allows using an `f64` world: Shapes are converted to an `f32` representation, and inputs are converted back.