### PR TITLE
Fix building with indirect dependency on self.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,12 @@ jobs:
           name: build nphysics_testbed3d
           command: cargo build --verbose -p nphysics_testbed3d;
       - run:
+          name: build nphysics_testbed2d with fluids
+          command: cd build/nphysics_testbed2d && cargo build --verbose --features=fluids;
+      - run:
+          name: build nphysics_testbed3d with fluids
+          command: cd build/nphysics_testbed3d && cargo build --verbose --features=fluids;
+      - run:
           name: test nphysics2d
           command: cargo test --verbose -p nphysics2d;
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ members = [ "build/nphysics2d", "build/nphysics_testbed2d", "examples2d",
 #[patch.crates-io]
 #ncollide2d = { path = "../ncollide/build/ncollide2d" }
 #ncollide3d = { path = "../ncollide/build/ncollide3d" }
+
+[patch.crates-io]
+nphysics2d = { path = "build/nphysics2d" }
+nphysics3d = { path = "build/nphysics3d" }


### PR DESCRIPTION
Building without a [patch.crates-io] for nphysics itself breaks when
using salva, because salva then pulls in another version of nphysics
through crates.io. This [patch] section in Cargo.toml makes sure that
salva will use the same working copy of nphysics.