### PR TITLE
Re-export nalgebra and ncollide. Fixes #257

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,12 @@ pub mod volumetric;
 pub mod world;
 // mod tests;
 
+pub use nalgebra;
+#[cfg(feature = "dim2")]
+pub use ncollide2d;
+#[cfg(feature = "dim3")]
+pub use ncollide3d;
+
 /// Compilation flags dependent aliases for mathematical types.
 #[cfg(feature = "dim3")]
 pub mod math {


### PR DESCRIPTION
Not sure how you feel regarding #257 but it's more or less standard to re-export dependencies from within the library. Avoids versioning issues and conflicts with other crates. Also makes the Cargo.toml a lot cleaner.

Just drop the PR if you don't agree.