### PR TITLE
Add a method to retrieve the number of parts of a body.

### DIFF
--- a/src/object/body.rs
+++ b/src/object/body.rs
@@ -212,6 +212,9 @@ pub trait Body<N: RealField>: Downcast + Send + Sync {
     /// Put this body to sleep.
     fn deactivate(&mut self);
 
+    /// The number of parts of this body.
+    fn num_parts(&self) -> usize;
+
     /// A reference to the specified body part.
     fn part(&self, i: usize) -> Option<&dyn BodyPart<N>>;
 

--- a/src/object/fem_surface.rs
+++ b/src/object/fem_surface.rs
@@ -839,6 +839,10 @@ impl<N: RealField> Body<N> for FEMSurface<N> {
         self.activation.set_deactivation_threshold(threshold)
     }
 
+    fn num_parts(&self) -> usize {
+        self.elements.len()
+    }
+
     fn part(&self, id: usize) -> Option<&dyn BodyPart<N>> {
         self.elements.get(id).map(|b| b as &dyn BodyPart<N>)
     }

--- a/src/object/fem_volume.rs
+++ b/src/object/fem_volume.rs
@@ -909,6 +909,10 @@ impl<N: RealField> Body<N> for FEMVolume<N> {
         self.activation.set_deactivation_threshold(threshold)
     }
 
+    fn num_parts(&self) -> usize {
+        self.elements.len()
+    }
+
     fn part(&self, id: usize) -> Option<&dyn BodyPart<N>> {
         self.elements.get(id).map(|e| e as &dyn BodyPart<N>)
     }

--- a/src/object/ground.rs
+++ b/src/object/ground.rs
@@ -62,8 +62,17 @@ impl<N: RealField> Body<N> for Ground<N> {
     }
 
     #[inline]
-    fn part(&self, _: usize) -> Option<&dyn BodyPart<N>> {
-        Some(self)
+    fn num_parts(&self) -> usize {
+        1
+    }
+
+    #[inline]
+    fn part(&self, i: usize) -> Option<&dyn BodyPart<N>> {
+        if i == 0 {
+            Some(self)
+        } else {
+            None
+        }
     }
 
     #[inline]

--- a/src/object/mass_constraint_system.rs
+++ b/src/object/mass_constraint_system.rs
@@ -504,6 +504,10 @@ impl<N: RealField> Body<N> for MassConstraintSystem<N> {
         self.velocities.fill(N::zero());
     }
 
+    fn num_parts(&self) -> usize {
+        self.elements.len()
+    }
+
     fn part(&self, id: usize) -> Option<&dyn BodyPart<N>> {
         self.elements.get(id).map(|e| e as &dyn BodyPart<N>)
     }

--- a/src/object/mass_spring_system.rs
+++ b/src/object/mass_spring_system.rs
@@ -643,6 +643,10 @@ impl<N: RealField> Body<N> for MassSpringSystem<N> {
         self.velocities.fill(N::zero());
     }
 
+    fn num_parts(&self) -> usize {
+        self.elements.len()
+    }
+
     fn part(&self, id: usize) -> Option<&dyn BodyPart<N>> {
         self.elements.get(id).map(|e| e as &dyn BodyPart<N>)
     }

--- a/src/object/multibody.rs
+++ b/src/object/multibody.rs
@@ -776,6 +776,11 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
 
 impl<N: RealField> Body<N> for Multibody<N> {
     #[inline]
+    fn num_parts(&self) -> usize {
+        self.rbs.len()
+    }
+
+    #[inline]
     fn part(&self, id: usize) -> Option<&dyn BodyPart<N>> {
         self.link(id).map(|l| l as &dyn BodyPart<N>)
     }

--- a/src/object/rigid_body.rs
+++ b/src/object/rigid_body.rs
@@ -619,8 +619,17 @@ impl<N: RealField> Body<N> for RigidBody<N> {
     }
 
     #[inline]
-    fn part(&self, _: usize) -> Option<&dyn BodyPart<N>> {
-        Some(self)
+    fn num_parts(&self) -> usize {
+        1
+    }
+
+    #[inline]
+    fn part(&self, i: usize) -> Option<&dyn BodyPart<N>> {
+        if i == 0 {
+            Some(self)
+        } else {
+            None
+        }
     }
 
     #[inline]

--- a/src_testbed/engine.rs
+++ b/src_testbed/engine.rs
@@ -372,7 +372,7 @@ impl GraphicsManager {
     ) {
         let color = self.ground_color;
         let node = FluidNode::new(
-            na::convert(particle_radius),
+            na::convert_unchecked(particle_radius) as f32,
             &boundary.positions,
             color,
             window,
@@ -390,7 +390,7 @@ impl GraphicsManager {
         color: Point3<f32>,
     ) {
         let node = FluidNode::new(
-            na::convert(particle_radius),
+            na::convert_unchecked(particle_radius) as f32,
             &fluid.positions,
             color,
             window,

--- a/src_testbed/objects/fluid.rs
+++ b/src_testbed/objects/fluid.rs
@@ -38,7 +38,8 @@ impl Fluid {
             let mut ball_gfx = gfx.add_circle(radius);
             #[cfg(feature = "dim3")]
             let mut ball_gfx = gfx.add_sphere(radius);
-            let c: Vector<f32> = na::convert(c.coords);
+            let c: Vector<f64> = na::convert_unchecked(c.coords);
+            let c: Vector<f32> = na::convert(c);
             ball_gfx.set_local_translation(c.into());
             balls_gfx.push(ball_gfx);
         }
@@ -91,7 +92,8 @@ impl Fluid {
 
         for (i, (pt, ball)) in centers.iter().zip(self.balls_gfx.iter_mut()).enumerate() {
             ball.set_visible(true);
-            let c: Vector<f32> = na::convert(pt.coords);
+            let c: Vector<f64> = na::convert_unchecked(pt.coords);
+            let c: Vector<f32> = na::convert(c);
             ball.set_local_translation(c.into());
 
             let color = match mode {
@@ -99,7 +101,8 @@ impl Fluid {
                 FluidRenderingMode::VelocityColor { min, max } => {
                     let start = self.base_color.coords;
                     let end = Vector3::new(1.0, 0.0, 0.0);
-                    let vel: Vector<f32> = na::convert(velocities[i]);
+                    let vel: Vector<f64> = na::convert_unchecked(velocities[i]);
+                    let vel: Vector<f32> = na::convert(vel);
                     let t = (vel.norm() - min) / (max - min);
                     start.lerp(&end, na::clamp(t, 0.0, 1.0)).into()
                 }


### PR DESCRIPTION
This adds a `body.num_parts` method to retrieve the number of parts of a body.
Now, `RigidBody` and `Ground` will return `None` for all parts index other than 0.

This is a breaking change because this adds a method to the `Body` trait.