### PR TITLE
Expose ability to get `MultibodyLink` parent ID

### DIFF
--- a/src/object/multibody_link.rs
+++ b/src/object/multibody_link.rs
@@ -134,6 +134,16 @@ impl<N: RealField> MultibodyLink<N> {
     pub fn link_id(&self) -> usize {
         self.internal_id
     }
+
+    /// The handle of the parent link.
+    #[inline]
+    pub fn parent_id(&self) -> Option<usize> {
+        if self.internal_id != 0 {
+            Some(self.parent_internal_id)
+        } else {
+            None
+        }
+    }
 }
 
 impl<N: RealField> BodyPart<N> for MultibodyLink<N> {


### PR DESCRIPTION
As per the (incredibly short) conversation on Discord. This makes it *much* easier to do a broad phase collision filter preventing collisions with ancestor links while allowing collisions with sibling links.