### PR TITLE
Don't pull in stdweb by default

### DIFF
--- a/build/nphysics2d/Cargo.toml
+++ b/build/nphysics2d/Cargo.toml
@@ -12,7 +12,8 @@ license = "BSD-3-Clause"
 edition = "2018"
 
 [features]
-default = [ "dim2", "stdweb" , "instant/stdweb"]
+default = [ "dim2" ]
+use-stdweb = [ "stdweb" , "instant/stdweb" ]
 use-wasm-bindgen = [ "dim2", "wasm-bindgen", "web-sys" , "instant/wasm-bindgen" ]
 dim2    = [ ]
 # Improve numerical stability when working with fixed-point numbers

--- a/build/nphysics3d/Cargo.toml
+++ b/build/nphysics3d/Cargo.toml
@@ -12,7 +12,8 @@ license = "BSD-3-Clause"
 edition = "2018"
 
 [features]
-default = [ "dim3", "stdweb" , "instant/stdweb"]
+default = [ "dim3" ]
+use-stdweb = [ "stdweb" , "instant/stdweb" ]
 use-wasm-bindgen = [ "dim3", "wasm-bindgen", "web-sys", "instant/wasm-bindgen"]
 dim3    = [ ]
 


### PR DESCRIPTION
Web stuff bloats the dependency graph for downstream crates who don't need it.