### PR TITLE
Add maximum target velocity to joint motors

### DIFF
--- a/src/joint/joint_motor.rs
+++ b/src/joint/joint_motor.rs
@@ -7,6 +7,8 @@ use num::Zero;
 pub struct JointMotor<V, N: RealField> {
     /// The velocity the motor will attempt to reach.
     pub desired_velocity: V,
+    /// The maximum velocity the motor will attempt to reach.
+    pub max_velocity: N,
     /// The maximum force deliverable by the motor.
     pub max_force: N,
     /// Whether or not the motor is active.
@@ -20,6 +22,7 @@ impl<V: Zero, N: RealField> JointMotor<V, N> {
     pub fn new() -> Self {
         JointMotor {
             desired_velocity: V::zero(),
+            max_velocity: N::max_value(),
             max_force: N::max_value(),
             enabled: false,
         }

--- a/src/joint/prismatic_joint.rs
+++ b/src/joint/prismatic_joint.rs
@@ -118,6 +118,16 @@ impl<N: RealField> PrismaticJoint<N> {
         self.motor.desired_velocity = vel;
     }
 
+    /// The max angular velocity that the joint motor will attempt.
+    pub fn max_angular_motor_velocity(&self) -> N {
+        self.motor.max_velocity
+    }
+
+    /// Set the maximum angular velocity that the joint motor will attempt.
+    pub fn set_max_angular_motor_velcoity(&mut self, max_vel: N) {
+        self.motor.max_velocity = max_vel;
+    }
+
     /// The maximum force that can be output by the joint motor.
     pub fn max_linear_motor_force(&self) -> N {
         self.motor.max_force

--- a/src/joint/revolute_joint.rs
+++ b/src/joint/revolute_joint.rs
@@ -159,6 +159,16 @@ impl<N: RealField> RevoluteJoint<N> {
         self.motor.desired_velocity = vel;
     }
 
+    /// The max angular velocity that the joint motor will attempt.
+    pub fn max_angular_motor_velocity(&self) -> N {
+        self.motor.max_velocity
+    }
+
+    /// Set the maximum angular velocity that the joint motor will attempt.
+    pub fn set_max_angular_motor_velcoity(&mut self, max_vel: N) {
+        self.motor.max_velocity = max_vel;
+    }
+
     /// The maximum torque that can be delivered by the joint motor.
     pub fn max_angular_motor_torque(&self) -> N {
         self.motor.max_force

--- a/src/joint/unit_joint.rs
+++ b/src/joint/unit_joint.rs
@@ -71,10 +71,10 @@ pub fn unit_joint_velocity_constraints<N: RealField, J: UnitJoint<N>>(
         multibody.inv_mass_mul_unit_joint_force(link, dof_id, N::one(), &mut jacobians[wj_id..]);
 
         let inv_r = jacobians[wj_id + link.assembly_id + dof_id]; // = J^t * M^-1 J
-        let rhs = dvel
-            - motor
-                .desired_velocity
-                .clamp(-motor.max_velocity, motor.max_velocity);
+        let velocity = motor
+            .desired_velocity
+            .clamp(-motor.max_velocity, motor.max_velocity);
+        let rhs = dvel - velocity;
         let limits = motor.impulse_limits();
         let impulse_id = link.impulse_id + dof_id * 3;
 

--- a/src/joint/unit_joint.rs
+++ b/src/joint/unit_joint.rs
@@ -60,7 +60,8 @@ pub fn unit_joint_velocity_constraints<N: RealField, J: UnitJoint<N>>(
     let mut is_min_constraint_active = false;
     let joint_velocity = multibody.joint_velocity(link);
 
-    if joint.motor().enabled {
+    let motor = joint.motor();
+    if motor.enabled {
         let dvel = joint_velocity[dof_id] + ext_vels[link.assembly_id];
 
         DVectorSliceMut::from_slice(&mut jacobians[*ground_j_id..], ndofs).fill(N::zero());
@@ -70,8 +71,11 @@ pub fn unit_joint_velocity_constraints<N: RealField, J: UnitJoint<N>>(
         multibody.inv_mass_mul_unit_joint_force(link, dof_id, N::one(), &mut jacobians[wj_id..]);
 
         let inv_r = jacobians[wj_id + link.assembly_id + dof_id]; // = J^t * M^-1 J
-        let rhs = dvel - joint.motor().desired_velocity;
-        let limits = joint.motor().impulse_limits();
+        let rhs = dvel
+            - motor
+                .desired_velocity
+                .clamp(-motor.max_velocity, motor.max_velocity);
+        let limits = motor.impulse_limits();
         let impulse_id = link.impulse_id + dof_id * 3;
 
         let constraint = BilateralGroundConstraint {


### PR DESCRIPTION
Adds a maximum target velocity to the joint motors.

As per the conversation on Discord: being able to specify a maximum velocity on the joint motors helps with loading URDF files (#268) without the defining new types.