### PR TITLE
Add methods for managing children of multibody descriptions

### DIFF
--- a/src/object/multibody.rs
+++ b/src/object/multibody.rs
@@ -1348,6 +1348,16 @@ impl<N: RealField> MultibodyDesc<N> {
         }
     }
 
+    /// Returns the children of this multibody.
+    pub fn children(&self) -> &[MultibodyDesc<N>] {
+        &self.children
+    }
+
+    /// Returns a mutable list of children of this multibody.
+    pub fn children_mut(&mut self) -> &mut [MultibodyDesc<N>] {
+        &mut self.children
+    }
+
     /// Add a children link to the multibody link represented by `self`.
     pub fn add_child<J: Joint<N>>(&mut self, joint: J) -> &mut MultibodyDesc<N> {
         let child = MultibodyDesc::new(joint);

--- a/src/object/multibody.rs
+++ b/src/object/multibody.rs
@@ -1358,12 +1358,18 @@ impl<N: RealField> MultibodyDesc<N> {
         &mut self.children
     }
 
-    /// Add a children link to the multibody link represented by `self`.
+    /// Add a child link to the multibody link represented by `self`.
     pub fn add_child<J: Joint<N>>(&mut self, joint: J) -> &mut MultibodyDesc<N> {
         let child = MultibodyDesc::new(joint);
 
         self.children.push(child);
         self.children.last_mut().unwrap()
+    }
+
+    /// Adds the description as a child link to the multibody link represented by `self`.
+    pub fn add_child_desc(&mut self, child: MultibodyDesc<N>) -> &mut Self {
+        self.children.push(child);
+        self
     }
 
     /// Sets the joint of this multibody builder.


### PR DESCRIPTION
Adds methods to view the current children of  a multibody description as well as adding a child link from a full multibody description.