### PR TITLE
Correct typo in joint max angular velocity

### DIFF
--- a/src/joint/prismatic_joint.rs
+++ b/src/joint/prismatic_joint.rs
@@ -124,7 +124,7 @@ impl<N: RealField> PrismaticJoint<N> {
     }
 
     /// Set the maximum angular velocity that the joint motor will attempt.
-    pub fn set_max_angular_motor_velcoity(&mut self, max_vel: N) {
+    pub fn set_max_angular_motor_velocity(&mut self, max_vel: N) {
         self.motor.max_velocity = max_vel;
     }
 

--- a/src/joint/revolute_joint.rs
+++ b/src/joint/revolute_joint.rs
@@ -165,7 +165,7 @@ impl<N: RealField> RevoluteJoint<N> {
     }
 
     /// Set the maximum angular velocity that the joint motor will attempt.
-    pub fn set_max_angular_motor_velcoity(&mut self, max_vel: N) {
+    pub fn set_max_angular_motor_velocity(&mut self, max_vel: N) {
         self.motor.max_velocity = max_vel;
     }
 


### PR DESCRIPTION
Correct typo present in the methods for setting max angular motor velocity.